### PR TITLE
fix: override default install directories for `rpath` consistency

### DIFF
--- a/install.rb
+++ b/install.rb
@@ -57,7 +57,7 @@ FileUtils.mkdir_p options[:install]
 prefix = File.realpath options[:install]
 
 # print and run a command
-def exe(cmd)
+def runCommand(cmd)
   puts "[+++] #{cmd}"
   system cmd or raise "FAILED: #{cmd}"
 end
@@ -90,8 +90,8 @@ meson = {
 
 # run meson
 if Dir.exists?(options[:build])
-  exe "#{meson[:config]} || #{meson[:setup]}"
+  runCommand "#{meson[:config]} || #{meson[:setup]}"
 else
-  exe meson[:setup]
+  runCommand meson[:setup]
 end
-exe meson[:install]
+runCommand meson[:install]

--- a/meson.build
+++ b/meson.build
@@ -8,10 +8,10 @@ project(
 project_inc = include_directories('src')
 
 project_lib_install_dir = 'lib' # to keep it the same for different Linux distributions
-project_exe_install_dir = 'bin'
+project_bin_install_dir = 'bin'
 
 project_lib_rpath = '$ORIGIN'
-project_exe_rpath = ':'.join([
+project_bin_rpath = ':'.join([
   '$ORIGIN/../' + project_lib_install_dir,
   get_option('hipo') + '/lib'
 ])

--- a/meson.build
+++ b/meson.build
@@ -7,11 +7,14 @@ project(
 
 project_inc = include_directories('src')
 
+project_lib_install_dir = 'lib' # to keep it the same for different Linux distributions
+project_exe_install_dir = 'bin'
+
+project_lib_rpath = '$ORIGIN'
 project_exe_rpath = ':'.join([
-  '$ORIGIN/../lib',
+  '$ORIGIN/../' + project_lib_install_dir,
   get_option('hipo') + '/lib'
 ])
-project_lib_rpath = '$ORIGIN'
 
 fmt_dep  = dependency('fmt')
 hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: '-DCMAKE_PREFIX_PATH=' + get_option('hipo'))

--- a/src/algorithms/clas12/fiducial_cuts/meson.build
+++ b/src/algorithms/clas12/fiducial_cuts/meson.build
@@ -13,8 +13,8 @@ algo_lib = shared_library(
   dependencies:        services_dep,
   link_with:           services_lib,
   install:             true,
-  install_rpath:       project_lib_rpath,
   install_dir:         project_lib_install_dir,
+  install_rpath:       project_lib_rpath,
 )
 
 install_headers(algo_headers, subdir : meson.project_name())

--- a/src/algorithms/clas12/fiducial_cuts/meson.build
+++ b/src/algorithms/clas12/fiducial_cuts/meson.build
@@ -12,8 +12,9 @@ algo_lib = shared_library(
   include_directories: project_inc,
   dependencies:        services_dep,
   link_with:           services_lib,
-  install_rpath:       project_lib_rpath,
   install:             true,
+  install_rpath:       project_lib_rpath,
+  install_dir:         project_lib_install_dir,
 )
 
 install_headers(algo_headers, subdir : meson.project_name())

--- a/src/iguana/meson.build
+++ b/src/iguana/meson.build
@@ -11,8 +11,9 @@ iguana_lib = shared_library(
   iguana_sources,
   include_directories: project_inc,
   link_with:           [ algo_lib, services_lib ],
-  install_rpath:       project_lib_rpath,
   install:             true,
+  install_dir:         project_lib_install_dir,
+  install_rpath:       project_lib_rpath,
 )
 
 install_headers(iguana_headers, subdir : meson.project_name())

--- a/src/services/meson.build
+++ b/src/services/meson.build
@@ -13,8 +13,9 @@ services_lib = shared_library(
   services_sources,
   include_directories: project_inc,
   dependencies:        fmt_dep,
-  install_rpath:       project_lib_rpath,
   install:             true,
+  install_dir:         project_lib_install_dir,
+  install_rpath:       project_lib_rpath,
 )
 
 services_dep = declare_dependency(

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -1,10 +1,10 @@
-test_exe = executable(
+test_bin = executable(
   'run',
   'main.cc',
   include_directories: project_inc,
   dependencies:        [ fmt_dep, hipo_dep ],
   link_with:           iguana_lib,
   install:             true,
-  install_dir:         project_exe_install_dir,
-  install_rpath:       project_exe_rpath,
+  install_dir:         project_bin_install_dir,
+  install_rpath:       project_bin_rpath,
 )

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -4,6 +4,7 @@ test_exe = executable(
   include_directories: project_inc,
   dependencies:        [ fmt_dep, hipo_dep ],
   link_with:           iguana_lib,
-  install_rpath:       project_exe_rpath,
   install:             true,
+  install_dir:         project_exe_install_dir,
+  install_rpath:       project_exe_rpath,
 )


### PR DESCRIPTION
Some distributions install libraries in `$prefix/lib/x86.../`, whereas others use `$prefix/lib`. This PR enforces `$prefix/lib`, to be consistent with the installation `rpath`; this is a stopgap until I can figure out how to set the installation's `rpath` automatically.