### PR TITLE
refactor!: regress `c++20` to `c++17`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'cpp',
   version: '0.0.0',
   license: 'LGPLv3',
-  default_options: [ 'cpp_std=c++20' ],
+  default_options: [ 'cpp_std=c++17' ],
 )
 
 project_inc = include_directories('src')

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -28,7 +28,7 @@ namespace iguana::clas12 {
     std::set<int> acceptedRows;
     for(int row = 0; row < inBanks.at("particles").getRows(); row++) {
       auto pid    = inBanks.at("particles").get("pid", row);
-      auto accept = m_opt.pids.contains(pid);
+      auto accept = m_opt.pids.find(pid) != m_opt.pids.end();
       if(accept) acceptedRows.insert(row);
       m_log->Debug("input PID {} -- accept = {}", pid, accept);
     }
@@ -37,20 +37,25 @@ namespace iguana::clas12 {
     switch(m_opt.mode) {
 
       case EventBuilderFilterOptions::Modes::blank:
-        outBanks.at("particles").setRows(inBanks.at("particles").getRows());
-        for(int row = 0; row < inBanks.at("particles").getRows(); row++) {
-          if(acceptedRows.contains(row))
-            CopyBankRow(inBanks.at("particles"), row, outBanks.at("particles"), row);
-          else
-            BlankRow(outBanks.at("particles"), row);
+        {
+          outBanks.at("particles").setRows(inBanks.at("particles").getRows());
+          for(int row = 0; row < inBanks.at("particles").getRows(); row++) {
+            if(acceptedRows.find(row) != acceptedRows.end())
+              CopyBankRow(inBanks.at("particles"), row, outBanks.at("particles"), row);
+            else
+              BlankRow(outBanks.at("particles"), row);
+          }
+          break;
         }
-        break;
 
       case EventBuilderFilterOptions::Modes::compact:
-        outBanks.at("particles").setRows(acceptedRows.size());
-        for(int row = 0; auto acceptedRow : acceptedRows)
-          CopyBankRow(inBanks.at("particles"), acceptedRow, outBanks.at("particles"), row++);
-        break;
+        {
+          outBanks.at("particles").setRows(acceptedRows.size());
+          int row = 0;
+          for(auto acceptedRow : acceptedRows)
+            CopyBankRow(inBanks.at("particles"), acceptedRow, outBanks.at("particles"), row++);
+          break;
+        }
 
       default:
         Throw("unknown 'mode' option");

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -8,7 +8,7 @@ namespace iguana {
 
   bool Algorithm::MissingInputBanks(BankMap banks, std::set<std::string> keys) {
     for(auto key : keys) {
-      if(!banks.contains(key)) {
+      if(banks.find(key) == banks.end()) {
         m_log->Error("Algorithm '{}' is missing the input bank '{}'", m_name, key);
         m_log->Error("  => the following input banks are required by '{}':", m_name);
         for(auto k : keys)

--- a/src/services/Logger.h
+++ b/src/services/Logger.h
@@ -34,8 +34,8 @@ namespace iguana {
       template <typename... VALUES>
         void Print(Level lev, std::string message, VALUES... vals) {
           if(lev >= m_level) {
-            if(m_level_names.contains(lev)) {
-              auto prefix = fmt::format("[{}] [{}] ", m_level_names.at(lev), m_name);
+            if(auto it{m_level_names.find(lev)}; it != m_level_names.end()) {
+              auto prefix = fmt::format("[{}] [{}] ", it->second, m_name);
               fmt::print(
                   lev >= warn ? stderr : stdout,
                   fmt::runtime(prefix + message + "\n"),


### PR DESCRIPTION
- The current latest `gcc/g++` version `13.2.1 20230801` still uses C++ standard 17 as its default
- C++ 20 support in `clang` is still only partial
- Dependency `hipo4` also requires C++ 17

So until compilers catch up, we regress the C++ 20 features.