### PR TITLE
refactor: rename `Arbiter->Iguana` and organize `main.cc`

### DIFF
--- a/src/iguana/Iguana.cc
+++ b/src/iguana/Iguana.cc
@@ -1,8 +1,8 @@
-#include "Arbiter.h"
+#include "Iguana.h"
 
 namespace iguana {
 
-  Arbiter::Arbiter() {
+  Iguana::Iguana() {
     algo_map.insert({clas12_EventBuilderFilter, std::make_shared<clas12::EventBuilderFilter>()});
   }
 

--- a/src/iguana/Iguana.h
+++ b/src/iguana/Iguana.h
@@ -9,20 +9,20 @@
 
 namespace iguana {
 
-  class Arbiter {
+  class Iguana {
 
     public:
-      Arbiter();
-      ~Arbiter() {}
+      Iguana();
+      ~Iguana() {}
 
       // TODO: avoid listing the algos
-      // TODO: who should own the algorithm instances: Arbiter or the user?
+      // TODO: who should own the algorithm instances: Iguana or the user?
       enum algo {
         clas12_EventBuilderFilter
       };
 
       // TODO: make private
-      std::unordered_map<Arbiter::algo, std::shared_ptr<Algorithm>> algo_map;
+      std::unordered_map<Iguana::algo, std::shared_ptr<Algorithm>> algo_map;
 
   };
 }

--- a/src/iguana/meson.build
+++ b/src/iguana/meson.build
@@ -1,9 +1,9 @@
 iguana_headers = [
-  'Arbiter.h',
+  'Iguana.h',
 ]
 
 iguana_sources = [
-  'Arbiter.cc',
+  'Iguana.cc',
 ]
 
 iguana_lib = shared_library(


### PR DESCRIPTION
- rename `Arbiter` to `Iguana`
- tried to simplify test example `main.cc` as much as possible
  - unfortunately, still have to get the `schema` up front: https://github.com/gavalian/hipo/issues/30
  - best we can do for now is organize `main.cc` and add comments