### PR TITLE
refactor: use `vector` of banks for algorithm I/O

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -98,7 +98,7 @@ Base class `Algorithm` has virtual methods:
 
 #### `Run`
 - runs on every event
-- input and output are a set of banks (`std::unordered_map< std::string, hipo::bank>`)
+- input and output are a set of banks
 - runs the algorithm for a given event's bank(s)
 - should be thread-safe, _e.g._, no modification of instance members
 - usage:

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -9,7 +9,7 @@ namespace iguana::clas12 {
     };
   }
 
-  void EventBuilderFilter::Start(std::unordered_map<std::string, int> bankVecIndices) {
+  void EventBuilderFilter::Start(bank_index_cache_t &index_cache) {
 
     // set configuration
     m_log->SetLevel(Logger::Level::trace);
@@ -17,14 +17,14 @@ namespace iguana::clas12 {
     m_opt.pids = {11, 211, -211};
 
     // cache expected bank indices
-    CacheBankIndex(bankVecIndices, b_particle, "REC::Particle");
-    CacheBankIndex(bankVecIndices, b_calo,     "REC::Calorimeter");
+    CacheBankIndex(index_cache, b_particle, "REC::Particle");
+    CacheBankIndex(index_cache, b_calo,     "REC::Calorimeter");
     m_log->Error("{} {}", b_particle, b_calo);
 
   }
 
 
-  void EventBuilderFilter::Run(Algorithm::BankVec banks) {
+  void EventBuilderFilter::Run(bank_vec_t banks) {
     m_log->Debug("RUN {}", m_name);
 
     // get the banks

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -19,7 +19,6 @@ namespace iguana::clas12 {
     // cache expected bank indices
     CacheBankIndex(index_cache, b_particle, "REC::Particle");
     CacheBankIndex(index_cache, b_calo,     "REC::Calorimeter");
-    m_log->Error("{} {}", b_particle, b_calo);
 
   }
 

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "services/Algorithm.h"
+#include <set>
 
 namespace iguana::clas12 {
 
@@ -13,16 +14,11 @@ namespace iguana::clas12 {
   class EventBuilderFilter : public Algorithm {
 
     public:
-      EventBuilderFilter() : Algorithm("event_builder_filter") {
-        m_requiredBanks = {
-          "REC::Particle",
-          "REC::Calorimeter"
-        };
-      }
+      EventBuilderFilter();
       ~EventBuilderFilter() {}
 
-      void Start(std::unordered_map<std::string, int> bankVecOrder) override;
-      void Run(Algorithm::BankVec inBanks) override;
+      void Start(std::unordered_map<std::string, int> bankVecIndices) override;
+      void Run(Algorithm::BankVec banks) override;
       void Stop() override;
 
     private:

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
@@ -6,8 +6,6 @@ namespace iguana::clas12 {
 
   class EventBuilderFilterOptions {
     public:
-      enum Modes { blank, compact };
-      Modes mode = blank;
       std::set<int> pids = {11, 211};
   };
 
@@ -15,15 +13,21 @@ namespace iguana::clas12 {
   class EventBuilderFilter : public Algorithm {
 
     public:
-      EventBuilderFilter() : Algorithm("event_builder_filter") {}
+      EventBuilderFilter() : Algorithm("event_builder_filter") {
+        m_requiredBanks = {
+          "REC::Particle",
+          "REC::Calorimeter"
+        };
+      }
       ~EventBuilderFilter() {}
 
-      void Start() override;
-      Algorithm::BankMap Run(Algorithm::BankMap inBanks) override;
+      void Start(std::unordered_map<std::string, int> bankVecOrder) override;
+      void Run(Algorithm::BankVec inBanks) override;
       void Stop() override;
 
     private:
       EventBuilderFilterOptions m_opt;
+      int b_particle, b_calo;
 
   };
 

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
@@ -17,8 +17,8 @@ namespace iguana::clas12 {
       EventBuilderFilter();
       ~EventBuilderFilter() {}
 
-      void Start(std::unordered_map<std::string, int> bankVecIndices) override;
-      void Run(Algorithm::BankVec banks) override;
+      void Start(bank_index_cache_t &index_cache) override;
+      void Run(bank_vec_t banks) override;
       void Stop() override;
 
     private:

--- a/src/iguana/Iguana.h
+++ b/src/iguana/Iguana.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "services/Algorithm.h"
-#include <unordered_map>
 
 // TODO: avoid listing the algos
 #include "algorithms/clas12/event_builder_filter/EventBuilderFilter.h"

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -7,24 +7,24 @@ namespace iguana {
   }
 
   void Algorithm::Start() {
-    std::unordered_map<std::string, int> m;
+    bank_index_cache_t index_cache;
     int i = 0;
     for(auto requiredBank : m_requiredBanks)
-      m.insert({requiredBank, i++});
-    Start(m);
+      index_cache.insert({requiredBank, i++});
+    Start(index_cache);
   }
 
-  void Algorithm::CacheBankIndex(std::unordered_map<std::string, int> bankVecIndices, int &idx, std::string bankName) {
+  void Algorithm::CacheBankIndex(bank_index_cache_t index_cache, int &idx, std::string bankName) {
     try {
-      idx = bankVecIndices.at(bankName);
+      idx = index_cache.at(bankName);
     } catch(const std::out_of_range &o) {
       Throw(fmt::format("required input bank '{}' not found; cannot `Start` algorithm '{}'", bankName, m_name));
     }
     m_log->Debug("cached index of bank '{}' is {}", bankName, idx);
   }
 
-  std::shared_ptr<hipo::bank> Algorithm::GetBank(BankVec banks, int idx, std::string expectedBankName) {
-    std::shared_ptr<hipo::bank> result;
+  bank_ptr Algorithm::GetBank(bank_vec_t banks, int idx, std::string expectedBankName) {
+    bank_ptr result;
     try {
       result = banks.at(idx);
     } catch(const std::out_of_range &o) {
@@ -36,7 +36,7 @@ namespace iguana {
     return result;
   }
 
-  void Algorithm::CopyBankRow(std::shared_ptr<hipo::bank> srcBank, int srcRow, std::shared_ptr<hipo::bank> destBank, int destRow) {
+  void Algorithm::CopyBankRow(bank_ptr srcBank, int srcRow, bank_ptr destBank, int destRow) {
     // TODO: check srcBank->getSchema() == destBank.getSchema()
     for(int item = 0; item < srcBank->getSchema().getEntries(); item++) {
       auto val = srcBank->get(item, srcRow);
@@ -44,13 +44,13 @@ namespace iguana {
     }
   }
 
-  void Algorithm::BlankRow(std::shared_ptr<hipo::bank> bank, int row) {
+  void Algorithm::BlankRow(bank_ptr bank, int row) {
     for(int item = 0; item < bank->getSchema().getEntries(); item++) {
       bank->put(item, row, 0);
     }
   }
 
-  void Algorithm::ShowBanks(BankVec banks, std::string message, Logger::Level level) {
+  void Algorithm::ShowBanks(bank_vec_t banks, std::string message, Logger::Level level) {
     if(m_log->GetLevel() <= level) {
       if(message != "")
         m_log->Print(level, message);
@@ -59,7 +59,7 @@ namespace iguana {
     }
   }
 
-  void Algorithm::ShowBank(std::shared_ptr<hipo::bank> bank, std::string message, Logger::Level level) {
+  void Algorithm::ShowBank(bank_ptr bank, std::string message, Logger::Level level) {
     if(m_log->GetLevel() <= level) {
       if(message != "")
         m_log->Print(level, message);

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -6,17 +6,12 @@ namespace iguana {
     m_log = std::make_shared<Logger>(m_name);
   }
 
-  bool Algorithm::MissingInputBanks(BankMap banks, std::set<std::string> keys) {
-    for(auto key : keys) {
-      if(banks.find(key) == banks.end()) {
-        m_log->Error("Algorithm '{}' is missing the input bank '{}'", m_name, key);
-        m_log->Error("  => the following input banks are required by '{}':", m_name);
-        for(auto k : keys)
-          m_log->Error("     - {}", k);
-        return true;
-      }
-    }
-    return false;
+  void Algorithm::Start() {
+    std::unordered_map<std::string, int> m;
+    int i = 0;
+    for(auto requiredBank : m_requiredBanks)
+      m.insert({requiredBank, i});
+    Start(m);
   }
 
   void Algorithm::CopyBankRow(std::shared_ptr<hipo::bank> srcBank, int srcRow, std::shared_ptr<hipo::bank> destBank, int destRow) {
@@ -33,19 +28,21 @@ namespace iguana {
     }
   }
 
-  void Algorithm::ShowBanks(BankMap banks, std::string message, Logger::Level level) {
+  void Algorithm::ShowBanks(BankVec banks, std::string message, Logger::Level level) {
     if(m_log->GetLevel() <= level) {
-      m_log->Print(level, message);
-      for(auto [key,bank] : banks) {
-        m_log->Print(level, "BANK: '{}'", key);
+      if(message != "")
+        m_log->Print(level, message);
+      for(auto bank : banks)
         bank->show();
-      }
     }
   }
 
-  void Algorithm::ShowBanks(BankMap inBanks, BankMap outBanks, Logger::Level level) {
-    ShowBanks(inBanks,  "===== INPUT BANKS =====",  level);
-    ShowBanks(outBanks, "===== OUTPUT BANKS =====", level);
+  void Algorithm::ShowBank(std::shared_ptr<hipo::bank> bank, std::string message, Logger::Level level) {
+    if(m_log->GetLevel() <= level) {
+      if(message != "")
+        m_log->Print(level, message);
+      bank->show();
+    }
   }
 
   void Algorithm::Throw(std::string message) {

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -1,16 +1,13 @@
 #pragma once
 
+#include "TypeDefs.h"
 #include "Logger.h"
-#include <hipo4/bank.h>
-#include <vector>
 
 namespace iguana {
 
   class Algorithm {
 
     public:
-
-      using BankVec = std::vector<std::shared_ptr<hipo::bank>>;
 
       /// Algorithm base class constructor
       /// @param name the unique name for a derived class instance
@@ -25,53 +22,53 @@ namespace iguana {
       virtual void Start();
 
       /// Initialize an algorithm before any events are processed
-      /// @param bankVecIndices The `Run` method will use these indices to access banks
-      virtual void Start(std::unordered_map<std::string, int> bankVecIndices) = 0;
+      /// @param index_cache The `Run` method will use these indices to access banks
+      virtual void Start(bank_index_cache_t &index_cache) = 0;
 
       /// Run an algorithm
       /// @param banks the set of banks to process
-      virtual void Run(BankVec banks) = 0;
+      virtual void Run(bank_vec_t banks) = 0;
 
       /// Finalize an algorithm after all events are processed
       virtual void Stop() = 0;
 
     protected:
 
-      /// Cache the index of a bank in a `BankVec`; throws an exception if the bank is not found
-      /// @param bankVecIndices the relation between bank name and `BankVec` index
-      /// @param idx a reference to the `BankVec` index of the bank
+      /// Cache the index of a bank in a `bank_vec_t`; throws an exception if the bank is not found
+      /// @param index_cache the relation between bank name and `bank_vec_t` index
+      /// @param idx a reference to the `bank_vec_t` index of the bank
       /// @param bankName the name of the bank
-      void CacheBankIndex(std::unordered_map<std::string, int> bankVecIndices, int &idx, std::string bankName);
+      void CacheBankIndex(bank_index_cache_t index_cache, int &idx, std::string bankName);
 
-      /// Get the pointer to a bank from a `BankVec`; optionally checks if the bank name matches the expectation
-      /// @param banks the `BankVec` from which to get the specified bank
+      /// Get the pointer to a bank from a `bank_vec_t`; optionally checks if the bank name matches the expectation
+      /// @param banks the `bank_vec_t` from which to get the specified bank
       /// @param idx the index of `banks` of the specified bank
       /// @param expectedBankName if specified, checks that the specified bank has this name
-      std::shared_ptr<hipo::bank> GetBank(BankVec banks, int idx, std::string expectedBankName="");
+      bank_ptr GetBank(bank_vec_t banks, int idx, std::string expectedBankName="");
 
       /// Copy a row from one bank to another, assuming their schemata are equivalent
       /// @param srcBank the source bank
       /// @param srcRow the row in `srcBank` to copy from
       /// @param destBank the destination bank
       /// @param destRow the row in `destBank` to copy to
-      void CopyBankRow(std::shared_ptr<hipo::bank> srcBank, int srcRow, std::shared_ptr<hipo::bank> destBank, int destRow);
+      void CopyBankRow(bank_ptr srcBank, int srcRow, bank_ptr destBank, int destRow);
 
       /// Blank a row, setting all items to zero
       /// @param bank the bank to modify
       /// @param row the row to blank
-      void BlankRow(std::shared_ptr<hipo::bank> bank, int row);
+      void BlankRow(bank_ptr bank, int row);
 
-      /// Dump all banks in a BankVec
+      /// Dump all banks in a `bank_vec_t`
       /// @param banks the banks to show
       /// @param message optionally print a header message
       /// @param level the log level
-      void ShowBanks(BankVec banks, std::string message="", Logger::Level level=Logger::trace);
+      void ShowBanks(bank_vec_t banks, std::string message="", Logger::Level level=Logger::trace);
 
       /// Dump a single bank
       /// @param bank the bank to show
       /// @param message optionally print a header message
       /// @param level the log level
-      void ShowBank(std::shared_ptr<hipo::bank> bank, std::string message="", Logger::Level level=Logger::trace);
+      void ShowBank(bank_ptr bank, std::string message="", Logger::Level level=Logger::trace);
 
       /// Stop the algorithm and throw a runtime exception
       /// @param message the error message

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -3,6 +3,7 @@
 #include "Logger.h"
 #include <hipo4/bank.h>
 #include <set>
+#include <vector>
 
 namespace iguana {
 
@@ -10,7 +11,7 @@ namespace iguana {
 
     public:
 
-      using BankMap = std::unordered_map<std::string, std::shared_ptr<hipo::bank>>;
+      using BankVec = std::vector<std::shared_ptr<hipo::bank>>;
 
       /// Algorithm base class constructor
       /// @param name the unique name for a derived class instance
@@ -19,24 +20,23 @@ namespace iguana {
       /// Algorithm base class destructor
       virtual ~Algorithm() {}
 
+      /// Initialize an algorithm before any events are processed.
+      /// The `Run` method will assume a default ordering of banks. 
+      /// Derived classes likely do not need to override this method.
+      virtual void Start();
+
       /// Initialize an algorithm before any events are processed
-      virtual void Start() = 0;
+      /// @param bankVecOrder The `Run` method will use this ordering
+      virtual void Start(std::unordered_map<std::string, int> bankVecOrder) = 0;
 
       /// Run an algorithm
-      /// @param inBanks the set of input banks
-      /// @return a set of output banks
-      virtual BankMap Run(BankMap inBanks) = 0;
+      /// @param inBanks the set of banks to process
+      virtual void Run(BankVec inBanks) = 0;
 
       /// Finalize an algorithm after all events are processed
       virtual void Stop() = 0;
 
     protected:
-
-      /// Check if `banks` contains all keys `keys`; this is useful for checking algorithm inputs are complete.
-      /// @param banks the set of (key,bank) pairs to check
-      /// @keys the required keys
-      /// @return true if `banks` is missing any keys in `keys`
-      bool MissingInputBanks(BankMap banks, std::set<std::string> keys);
 
       /// Copy a row from one bank to another, assuming their schemata are equivalent
       /// @param srcBank the source bank
@@ -50,17 +50,17 @@ namespace iguana {
       /// @param row the row to blank
       void BlankRow(std::shared_ptr<hipo::bank> bank, int row);
 
-      /// Dump all banks in a BankMap
+      /// Dump all banks in a BankVec
       /// @param banks the banks to show
       /// @param message optionally print a header message
       /// @param level the log level
-      void ShowBanks(BankMap banks, std::string message="", Logger::Level level=Logger::trace);
+      void ShowBanks(BankVec banks, std::string message="", Logger::Level level=Logger::trace);
 
-      /// Dump all input and output banks
-      /// @param inBanks the input banks
-      /// @param outBanks the output banks
+      /// Dump a single bank
+      /// @param bank the bank to show
+      /// @param message optionally print a header message
       /// @param level the log level
-      void ShowBanks(BankMap inBanks, BankMap outBanks, Logger::Level level=Logger::trace);
+      void ShowBank(std::shared_ptr<hipo::bank> bank, std::string message="", Logger::Level level=Logger::trace);
 
       /// Stop the algorithm and throw a runtime exception
       /// @param message the error message
@@ -68,6 +68,9 @@ namespace iguana {
 
       /// algorithm name
       std::string m_name;
+
+      /// list of required banks
+      std::set<std::string> m_requiredBanks;
 
       /// Logger
       std::shared_ptr<Logger> m_log;

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -2,7 +2,6 @@
 
 #include "Logger.h"
 #include <hipo4/bank.h>
-#include <set>
 #include <vector>
 
 namespace iguana {
@@ -26,17 +25,29 @@ namespace iguana {
       virtual void Start();
 
       /// Initialize an algorithm before any events are processed
-      /// @param bankVecOrder The `Run` method will use this ordering
-      virtual void Start(std::unordered_map<std::string, int> bankVecOrder) = 0;
+      /// @param bankVecIndices The `Run` method will use these indices to access banks
+      virtual void Start(std::unordered_map<std::string, int> bankVecIndices) = 0;
 
       /// Run an algorithm
-      /// @param inBanks the set of banks to process
-      virtual void Run(BankVec inBanks) = 0;
+      /// @param banks the set of banks to process
+      virtual void Run(BankVec banks) = 0;
 
       /// Finalize an algorithm after all events are processed
       virtual void Stop() = 0;
 
     protected:
+
+      /// Cache the index of a bank in a `BankVec`; throws an exception if the bank is not found
+      /// @param bankVecIndices the relation between bank name and `BankVec` index
+      /// @param idx a reference to the `BankVec` index of the bank
+      /// @param bankName the name of the bank
+      void CacheBankIndex(std::unordered_map<std::string, int> bankVecIndices, int &idx, std::string bankName);
+
+      /// Get the pointer to a bank from a `BankVec`; optionally checks if the bank name matches the expectation
+      /// @param banks the `BankVec` from which to get the specified bank
+      /// @param idx the index of `banks` of the specified bank
+      /// @param expectedBankName if specified, checks that the specified bank has this name
+      std::shared_ptr<hipo::bank> GetBank(BankVec banks, int idx, std::string expectedBankName="");
 
       /// Copy a row from one bank to another, assuming their schemata are equivalent
       /// @param srcBank the source bank
@@ -70,7 +81,7 @@ namespace iguana {
       std::string m_name;
 
       /// list of required banks
-      std::set<std::string> m_requiredBanks;
+      std::vector<std::string> m_requiredBanks;
 
       /// Logger
       std::shared_ptr<Logger> m_log;

--- a/src/services/Logger.cc
+++ b/src/services/Logger.cc
@@ -22,4 +22,8 @@ namespace iguana {
     return m_level;
   }
 
+  std::string Logger::Header(std::string message, int width) {
+    return fmt::format("{:=^{}}", message, width);
+  }
+
 }

--- a/src/services/Logger.h
+++ b/src/services/Logger.h
@@ -24,6 +24,7 @@ namespace iguana {
 
       void SetLevel(Level lev);
       Level GetLevel();
+      static std::string Header(std::string message, int width=50);
 
       template <typename... VALUES> void Trace(std::string message, VALUES... vals) { Print(trace, message, vals...); }
       template <typename... VALUES> void Debug(std::string message, VALUES... vals) { Print(debug, message, vals...); }

--- a/src/services/TypeDefs.h
+++ b/src/services/TypeDefs.h
@@ -1,0 +1,18 @@
+#include <memory>
+#include <vector>
+#include <unordered_map>
+
+#include <hipo4/bank.h>
+
+namespace iguana {
+
+  /// pointer to a HIPO bank
+  using bank_ptr = std::shared_ptr<hipo::bank>;
+
+  /// ordered list of HIPO bank pointers
+  using bank_vec_t = std::vector<bank_ptr>;
+
+  /// association between HIPO bank name and its index in a `bank_vec_t`
+  using bank_index_cache_t = std::unordered_map<std::string, int>;
+
+}

--- a/src/services/meson.build
+++ b/src/services/meson.build
@@ -1,4 +1,5 @@
 services_headers = [
+  'TypeDefs.h',
   'Logger.h',
   'Algorithm.h',
 ]

--- a/src/tests/main.cc
+++ b/src/tests/main.cc
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
   hipo::dictionary factory;
   reader.readDictionary(factory);
   auto particleBank = std::make_shared<hipo::bank>(factory.getSchema("REC::Particle"));
-  auto caloBank     = std::make_shared<hipo::bank>(factory.getSchema("REC::Calorimeter"));
+  auto caloBank     = std::make_shared<hipo::bank>(factory.getSchema("REC::Calorimeter"));  // TODO: remove when not needed (this is for testing)
 
   // event loop
   hipo::event event;

--- a/src/tests/main.cc
+++ b/src/tests/main.cc
@@ -1,6 +1,13 @@
 #include "iguana/Iguana.h"
 #include <hipo4/reader.h>
 
+void printParticles(std::string prefix, iguana::bank_ptr b) {
+  std::vector<int> pids;
+  for(int row=0; row<b->getRows(); row++)
+    pids.push_back(b->get("pid", row));
+  fmt::print("{}: {}\n", prefix, fmt::join(pids, ", "));
+}
+
 int main(int argc, char **argv) {
 
   // parse arguments
@@ -36,7 +43,9 @@ int main(int argc, char **argv) {
   int iEvent = 0;
   while(reader.next(event) && (iEvent++ < numEvents || numEvents == 0)) {
     event.getStructure(*particleBank);
+    printParticles("PIDS BEFORE FILTER ", particleBank);
     algo->Run({particleBank, caloBank});
+    printParticles("PIDS AFTER FILTER  ", particleBank);
   }
 
   /////////////////////////////////////////////////////

--- a/src/tests/main.cc
+++ b/src/tests/main.cc
@@ -29,13 +29,14 @@ int main(int argc, char **argv) {
   hipo::dictionary factory;
   reader.readDictionary(factory);
   auto particleBank = std::make_shared<hipo::bank>(factory.getSchema("REC::Particle"));
+  auto caloBank     = std::make_shared<hipo::bank>(factory.getSchema("REC::Calorimeter"));
 
   // event loop
   hipo::event event;
   int iEvent = 0;
   while(reader.next(event) && (iEvent++ < numEvents || numEvents == 0)) {
     event.getStructure(*particleBank);
-    auto resultBank = algo->Run({{"particles", particleBank}});
+    algo->Run({particleBank, caloBank});
   }
 
   /////////////////////////////////////////////////////


### PR DESCRIPTION
- Algorithm `Run` method now operates on a `BankVec`, a `std::vector` of bank pointers
  - `Run` now returns `void`; instead it is allowed to mutate the input `BankVec`; this saves some time by avoiding copying banks
  - `Start` will set the index of the `BankVec` for each required bank, so `Run` avoids hashing (_cf._ previous design's `BankMap`, an unordered map of bank names to bank pointers, which requires extensive hashing)
  - Creator algorithms will need a pointer to the "new" bank in the input `BankVec`
- Algorithms may be initialized one of two ways:
  - call `Start()`: a default (algorithm-dependent) ordering of banks will be assumed by `Run`
  - call `Start(std::unordered_map<std::string, int> m)`, where `m` provides the index of the `BankVec` for each bank


This design provides compatibility with @gavalian's idea of a `BankStore`:
```cpp
struct BankStore {
  std::vector<hipo::bank> banks;                 // the vector of banks
  std::unordered_map<std::string, int> bankMap;  // bank name -> index in `banks` for that bank
}
```
If a user wants to use a `BankStore`, they would write the following (pseudocode):
```cpp
Algorithm algo;
BankStore b = reader.getBanks(bank1, bank2);
algo.Start(b.bankMap);
while(event)
  algo.run(b.banks);
```
Alternatively, if a user wants to work with the banks and avoid the bank store, they need to know the order of the banks that the algorithm `Run` call expects (or change it using `Start(map)`):
```cpp
Algorithm algo;
hipo::bank bank1, bank2;
algo.Start();
while(event) {
  bank1 = event.get("bank1");
  bank2 = event.get("bank2");
  algo.run({bank1, bank2});
```
This alternative, while slower, may be preferred in the case where refactoring one's analysis code to use `BankStore` is difficult.