### PR TITLE
feat+build: improve algorithm configuration; colored log output; improve dependency resolution

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ env.hipo_version }}
       - name: build
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE 
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           cmake --build build -j2
           cmake --install build
       - run: tree hipo

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ env.hipo_version }}
       - name: build
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo -DBUILD_SHARED_LIBS=TRUE
           cmake --build build -j2
           cmake --install build
       - run: tree hipo

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,9 +14,13 @@ defaults:
   run:
     shell: bash
 
+env:
+  hipo_version: master
+  fmt_version: 9.1.0
+
 jobs:
 
-  # build
+  # dependencies
   #########################################################
 
   build_hipo:
@@ -27,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gavalian/hipo
+          ref: ${{ env.hipo_version }}
       - name: build
         run: |
           cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo
@@ -41,14 +46,40 @@ jobs:
           retention-days: 1
           path: hipo.tar.gz
 
+  build_fmt:
+    name: Build fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout fmt
+        uses: actions/checkout@v4
+        with:
+          repository: fmtlib/fmt
+          ref: ${{ env.fmt_version }}
+      - name: build
+        run: |
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt
+          cmake --build build -j2
+          cmake --install build
+      - run: tree fmt
+      - name: tar
+        run: tar czvf fmt{.tar.gz,}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build
+          retention-days: 1
+          path: fmt.tar.gz
+
+  # build
+  #########################################################
+
   build_iguana:
     name: Build Iguana
-    needs: [ build_hipo ]
+    needs:
+      - build_hipo
+      - build_fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: setup fmt
-        run: sudo apt install -y libfmt-dev
       - name: setup meson
         run: python -m pip install meson ninja
       - name: summarize dependencies
@@ -59,7 +90,8 @@ jobs:
           for dep in python ruby meson ninja ; do
             echo "| \`$dep\` | $($dep --version) |" >> $GITHUB_STEP_SUMMARY
           done
-          echo "| \`fmt\` | $(apt show libfmt-dev | grep -w Version) |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`fmt\` | ${{ env.fmt_version }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`hipo\` | ${{ env.hipo_version }} |" >> $GITHUB_STEP_SUMMARY
       - name: get build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -67,7 +99,7 @@ jobs:
       - name: untar build
         run: ls *.tar.gz | xargs -I{} tar xzvf {}
       - name: build iguana
-        run: ./install.rb --hipo hipo
+        run: ./install.rb --hipo hipo --fmt fmt
       - name: dump build log
         if: always()
         run: cat build-iguana/meson-logs/meson-log.txt
@@ -108,11 +140,11 @@ jobs:
 
   test_iguana:
     name: Test Iguana
-    needs: [ download_validation_files, build_iguana ]
+    needs: 
+      - download_validation_files
+      - build_iguana
     runs-on: ubuntu-latest
     steps:
-      - name: install dependencies
-        run: sudo apt install -y libfmt-dev
       - name: get build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ env.hipo_version }}
       - name: build
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           cmake --build build -j2
           cmake --install build
       - run: tree hipo

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 env:
-  hipo_version: master
+  hipo_version: 94e2cfc1ab93388680ba07088d9b63b68347ba92 # before hipo::bank::get and put were removed
   fmt_version: 9.1.0
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ env.hipo_version }}
       - name: build
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo -DBUILD_SHARED_LIBS=TRUE
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE 
           cmake --build build -j2
           cmake --install build
       - run: tree hipo

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,6 +98,7 @@ jobs:
           name: build
       - name: untar build
         run: ls *.tar.gz | xargs -I{} tar xzvf {}
+      - run: tree
       - name: build iguana
         run: ./install.rb --hipo hipo --fmt fmt
       - name: dump build log

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ env.hipo_version }}
       - name: build
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo
           cmake --build build -j2
           cmake --install build
       - run: tree hipo
@@ -57,7 +57,7 @@ jobs:
           ref: ${{ env.fmt_version }}
       - name: build
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           cmake --build build -j2
           cmake --install build
       - run: tree fmt

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 # build artifacts
+*.ini
 /build*/
 /iguana
-/bin
-/include
-/lib
 
 # dependencies
 hipo

--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ install.rb --help        # print the usage guide
 install.rb               # default: install to ./iguana
 ```
 Alternatively, use `meson` for more control.
+
+## Troubleshooting Notes
+
+- if you redirect `stdout` and `stderr` to a file, you may notice that `stderr` lines are out-of-order with respect to the `stdout` lines; for example:
+```bash
+myAnalysisProgram                    # stdout and stderr print when they happen; ordering appears correct
+
+myAnalysisProgram |& tee output.txt  # stderr prints when it happens, but stdout only prints when its buffer is full;
+                                     # ordering appears mixed up
+```
+To redirect output to a file with the ordering preserved, run your executable with `stdout` unbuffered:
+```bash
+stdbuf -o0 myAnalysisProgram |& tee output.txt
+```

--- a/install.rb
+++ b/install.rb
@@ -30,13 +30,24 @@ parser.on("--clean", "Remove the buildsystem at [BUILD DIR] beforehand")
 parser.on("--purge", "Remove the installation at [INSTALL DIR] beforehand")                 
 parser.parse!(into: options)
 
+# check for HIPO installation, or fallback to $HIPO
+options[:hipo] = ENV['HIPO'] unless Dir.exists? options[:hipo]
+
+# use realpaths for dependencies
+[ :hipo, :fmt ].each do |dep|
+  unless options[dep].nil?
+    if Dir.exists? options[dep]
+      options[dep] = File.realpath options[dep]
+    else
+      $stderr.puts "ERROR: directory '#{options[dep]}' for option '--#{dep.to_s}' does not exist"
+      exit 1
+    end
+  end
+end
+
 # print the options
 puts "SET OPTIONS:"
 options.each do |k,v| puts "#{k.to_s.rjust 15} => #{v}" end
-
-# check for HIPO installation, or fallback to $HIPO
-options[:hipo] = ENV['HIPO'] unless Dir.exists? options[:hipo]
-options[:hipo] = File.realpath options[:hipo] if Dir.exists? options[:hipo]
 
 # clean and purge
 def rmDir(dir,obj='files')

--- a/install.rb
+++ b/install.rb
@@ -33,6 +33,9 @@ parser.parse!(into: options)
 # check for HIPO installation, or fallback to $HIPO
 options[:hipo] = ENV['HIPO'] unless Dir.exists? options[:hipo]
 
+# fmt has a pkg-config file
+options[:fmt] += '/lib/pkgconfig' unless options[:fmt].nil?
+
 # use realpaths for dependencies
 [ :hipo, :fmt ].each do |dep|
   unless options[dep].nil?
@@ -86,7 +89,7 @@ meson = {
     'meson setup',
     "--prefix #{prefix}",
     buildOpt('cmake_prefix_path', options[:hipo]),
-    buildOpt('pkg_config_path', options[:fmt] + '/lib/pkgconfig'),
+    buildOpt('pkg_config_path', options[:fmt]),
     options[:build],
     SourceDir,
   ],
@@ -94,7 +97,7 @@ meson = {
     'meson configure',
     "--prefix #{prefix}",
     buildOpt('cmake_prefix_path', options[:hipo]),
-    buildOpt('pkg_config_path', options[:fmt] + '/lib/pkgconfig'),
+    buildOpt('pkg_config_path', options[:fmt]),
     options[:build],
   ],
   :install => [

--- a/install.rb
+++ b/install.rb
@@ -10,6 +10,7 @@ options = {
   build:   "#{Dir.pwd}/build-iguana",
   install: "#{Dir.pwd}/iguana",
   hipo:    "#{Dir.pwd}/hipo",
+  fmt:     nil,
   clean:   false,
   purge:   false,
 }
@@ -22,7 +23,8 @@ parser.on("-b", "--build [BUILD DIR]", "Directory for buildsystem", "Default: #{
 parser.separator ''
 parser.on("-i", "--install [INSTALL DIR]", "Directory for installation", "Default: #{options[:install]}")
 parser.separator ''
-parser.on("-h", "--hipo [HIPO DIR]", "Path to HIPO installation", "Default: #{options[:hipo]}", "if not found, tries env var $HIPO")
+parser.on("--hipo [HIPO DIR]", "Path to HIPO installation", "Default: #{options[:hipo]}", "if not found, tries env var $HIPO")
+parser.on("--fmt [FMT DIR]", "Path to fmt installation", "Default: assumes system installation" )
 parser.separator 'TROUBLESHOOTING:'
 parser.on("--clean", "Remove the buildsystem at [BUILD DIR] beforehand")                 
 parser.on("--purge", "Remove the installation at [INSTALL DIR] beforehand")                 
@@ -73,6 +75,7 @@ meson = {
     'meson setup',
     "--prefix #{prefix}",
     buildOpt('hipo', options[:hipo]),
+    buildOpt('fmt', options[:fmt]),
     options[:build],
     SourceDir,
   ],
@@ -80,6 +83,7 @@ meson = {
     'meson configure',
     "--prefix #{prefix}",
     buildOpt('hipo', options[:hipo]),
+    buildOpt('fmt', options[:fmt]),
     options[:build],
   ],
   :install => [

--- a/install.rb
+++ b/install.rb
@@ -51,7 +51,7 @@ options.each do |k,v| puts "#{k.to_s.rjust 15} => #{v}" end
 
 # set dependency package paths and generate native INI file
 cmake_prefix_path = [ options[:hipo] ].compact
-pkg_config_path   = [ options[:fmt]  ].compact
+pkg_config_path   = [ options[:fmt]  ].compact.map{ |path| path += '/lib/pkgconfig' }
 def singleQuotes(arr)
   "#{arr}".gsub /"/, "'"
 end

--- a/install.rb
+++ b/install.rb
@@ -86,7 +86,7 @@ meson = {
     'meson setup',
     "--prefix #{prefix}",
     buildOpt('hipo', options[:hipo]),
-    buildOpt('fmt', options[:fmt]),
+    buildOpt('pkg_config_path', options[:fmt]),
     options[:build],
     SourceDir,
   ],
@@ -94,7 +94,7 @@ meson = {
     'meson configure',
     "--prefix #{prefix}",
     buildOpt('hipo', options[:hipo]),
-    buildOpt('fmt', options[:fmt]),
+    buildOpt('pkg_config_path', options[:fmt]),
     options[:build],
   ],
   :install => [

--- a/install.rb
+++ b/install.rb
@@ -85,7 +85,7 @@ meson = {
   :setup => [
     'meson setup',
     "--prefix #{prefix}",
-    buildOpt('hipo', options[:hipo]),
+    buildOpt('cmake_prefix_path', options[:hipo]),
     buildOpt('pkg_config_path', options[:fmt] + '/lib/pkgconfig'),
     options[:build],
     SourceDir,
@@ -93,7 +93,7 @@ meson = {
   :config => [
     'meson configure',
     "--prefix #{prefix}",
-    buildOpt('hipo', options[:hipo]),
+    buildOpt('cmake_prefix_path', options[:hipo]),
     buildOpt('pkg_config_path', options[:fmt] + '/lib/pkgconfig'),
     options[:build],
   ],

--- a/install.rb
+++ b/install.rb
@@ -86,7 +86,7 @@ meson = {
     'meson setup',
     "--prefix #{prefix}",
     buildOpt('hipo', options[:hipo]),
-    buildOpt('pkg_config_path', options[:fmt]),
+    buildOpt('pkg_config_path', options[:fmt] + '/lib/pkgconfig'),
     options[:build],
     SourceDir,
   ],
@@ -94,7 +94,7 @@ meson = {
     'meson configure',
     "--prefix #{prefix}",
     buildOpt('hipo', options[:hipo]),
-    buildOpt('pkg_config_path', options[:fmt]),
+    buildOpt('pkg_config_path', options[:fmt] + '/lib/pkgconfig'),
     options[:build],
   ],
   :install => [

--- a/meson.build
+++ b/meson.build
@@ -12,19 +12,23 @@ project_lib_install_dir = 'lib' # to keep it the same for different Linux distri
 project_bin_install_dir = 'bin'
 
 dep_lib_rpaths = [
-  get_option('hipo') + '/lib'
+'$ORIGIN/../' + project_lib_install_dir,
+  get_option('hipo') + '/lib',
+]
+cmake_prefix_paths = [
+  get_option('hipo'),
 ]
 if get_option('fmt') != ''
   dep_lib_rpaths += get_option('fmt') + '/lib'
+  cmake_prefix_path += get_option('fmt')
 endif
-project_lib_rpath = '$ORIGIN'
-project_bin_rpath = ':'.join(['$ORIGIN/../' + project_lib_install_dir] + dep_lib_rpaths)
 
-hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: '-DCMAKE_PREFIX_PATH=' + get_option('hipo'))
-fmt_dep  = dependency(
-  'fmt',
-  cmake_args: get_option('fmt')!='' ? '-DCMAKE_PREFIX_PATH='+get_option('fmt') : '',
-)
+project_lib_rpath = '$ORIGIN'
+project_bin_rpath = ':'.join(dep_lib_rpaths)
+cmake_prefix_patharg = '-DCMAKE_PREFIX_PATH=' + ';'.join(cmake_prefix_paths)
+
+hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: cmake_prefix_path)
+fmt_dep  = dependency('fmt', method: 'cmake', cmake_args: cmake_prefix_path)
 
 subdir('src/services')
 subdir('src/algorithms')

--- a/meson.build
+++ b/meson.build
@@ -11,14 +11,23 @@ project_inc = include_directories('src')
 project_lib_install_dir = 'lib' # to keep it the same for different Linux distributions
 project_bin_install_dir = 'bin'
 
-project_lib_rpath = '$ORIGIN'
-project_bin_rpath = ':'.join([
-  '$ORIGIN/../' + project_lib_install_dir,
+dep_lib_rpaths = [
   get_option('hipo') + '/lib'
-])
+]
+if get_option('fmt') != ''
+  dep_lib_rpaths += get_option('fmt') + '/lib'
+endif
+project_lib_rpath = '$ORIGIN'
+project_bin_rpath = ':'.join(['$ORIGIN/../' + project_lib_install_dir] + dep_lib_rpaths)
 
-fmt_dep  = dependency('fmt')
-hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: '-DCMAKE_PREFIX_PATH=' + get_option('hipo'))
+fmt_dep  = dependency(
+  'fmt',
+  cmake_args: get_option('fmt')!='' ? '-DCMAKE_PREFIX_PATH='+get_option('fmt') : '',
+)
+hipo_dep = dependency(
+  'hipo4',
+  cmake_args: '-DCMAKE_PREFIX_PATH='+get_option('hipo'),
+)
 
 subdir('src/services')
 subdir('src/algorithms')

--- a/meson.build
+++ b/meson.build
@@ -24,11 +24,7 @@ fmt_dep  = dependency(
   'fmt',
   cmake_args: get_option('fmt')!='' ? '-DCMAKE_PREFIX_PATH='+get_option('fmt') : '',
 )
-hipo_dep = dependency(
-  'hipo4',
-  method: 'cmake',
-  cmake_args: '-DCMAKE_PREFIX_PATH='+get_option('hipo'),
-)
+hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: '-DCMAKE_PREFIX_PATH=' + get_option('hipo'))
 
 subdir('src/services')
 subdir('src/algorithms')

--- a/meson.build
+++ b/meson.build
@@ -8,13 +8,13 @@ project(
 
 project_inc = include_directories('src')
 
-dep_lib_rpaths = [ get_option('prefix') + '/' + get_option('libdir') ]
+dep_lib_rpaths = [ ]
 foreach path : get_option('cmake_prefix_path')
   dep_lib_rpaths += path + '/lib' # TODO: this adds hipo4 libs to the rpath; consider instead linking against hipo4 static lib
 endforeach
 
 project_lib_rpath = '$ORIGIN'
-project_bin_rpath = ':'.join(dep_lib_rpaths)
+project_bin_rpath = ':'.join( dep_lib_rpaths + [ '$ORIGIN/../' + get_option('libdir') ] )
 
 hipo_dep = dependency('hipo4')
 fmt_dep  = dependency('fmt')

--- a/meson.build
+++ b/meson.build
@@ -18,17 +18,13 @@ dep_lib_rpaths = [
 cmake_prefix_paths = [
   get_option('hipo'),
 ]
-if get_option('fmt') != ''
-  dep_lib_rpaths += get_option('fmt') + '/lib'
-  cmake_prefix_paths += get_option('fmt')
-endif
 
 project_lib_rpath = '$ORIGIN'
 project_bin_rpath = ':'.join(dep_lib_rpaths)
 cmake_prefix_path = '-DCMAKE_PREFIX_PATH=' + ';'.join(cmake_prefix_paths)
 
 hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: cmake_prefix_path)
-fmt_dep  = dependency('fmt', method: 'cmake', cmake_args: cmake_prefix_path)
+fmt_dep  = dependency('fmt')
 
 subdir('src/services')
 subdir('src/algorithms')

--- a/meson.build
+++ b/meson.build
@@ -11,10 +11,8 @@ project_inc = include_directories('src')
 project_lib_install_dir = 'lib' # to keep it the same for different Linux distributions
 project_bin_install_dir = 'bin'
 
-dep_lib_rpaths = [
-'$ORIGIN/../' + project_lib_install_dir,
-  get_option('hipo') + '/lib',
-]
+dep_lib_rpaths = [ '$ORIGIN/../' + project_lib_install_dir ]
+dep_lib_rpaths += get_option('cmake_prefix_path') # TODO: this is for hipo4; consider instead linking against hipo4 static lib
 
 project_lib_rpath = '$ORIGIN'
 project_bin_rpath = ':'.join(dep_lib_rpaths)

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ endif
 
 project_lib_rpath = '$ORIGIN'
 project_bin_rpath = ':'.join(dep_lib_rpaths)
-cmake_prefix_patharg = '-DCMAKE_PREFIX_PATH=' + ';'.join(cmake_prefix_paths)
+cmake_prefix_path = '-DCMAKE_PREFIX_PATH=' + ';'.join(cmake_prefix_paths)
 
 hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: cmake_prefix_path)
 fmt_dep  = dependency('fmt', method: 'cmake', cmake_args: cmake_prefix_path)

--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,7 @@ fmt_dep  = dependency(
 )
 hipo_dep = dependency(
   'hipo4',
+  method: 'cmake',
   cmake_args: '-DCMAKE_PREFIX_PATH='+get_option('hipo'),
 )
 

--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@ cmake_prefix_paths = [
 ]
 if get_option('fmt') != ''
   dep_lib_rpaths += get_option('fmt') + '/lib'
-  cmake_prefix_path += get_option('fmt')
+  cmake_prefix_paths += get_option('fmt')
 endif
 
 project_lib_rpath = '$ORIGIN'

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,9 @@ project_lib_install_dir = 'lib' # to keep it the same for different Linux distri
 project_bin_install_dir = 'bin'
 
 dep_lib_rpaths = [ '$ORIGIN/../' + project_lib_install_dir ]
-dep_lib_rpaths += get_option('cmake_prefix_path') # TODO: this is for hipo4; consider instead linking against hipo4 static lib
+foreach path : get_option('cmake_prefix_path')
+  dep_lib_rpaths += path + '/lib' # TODO: this adds hipo4 libs to the rpath; consider instead linking against hipo4 static lib
+endforeach
 
 project_lib_rpath = '$ORIGIN'
 project_bin_rpath = ':'.join(dep_lib_rpaths)

--- a/meson.build
+++ b/meson.build
@@ -20,11 +20,11 @@ endif
 project_lib_rpath = '$ORIGIN'
 project_bin_rpath = ':'.join(['$ORIGIN/../' + project_lib_install_dir] + dep_lib_rpaths)
 
+hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: '-DCMAKE_PREFIX_PATH=' + get_option('hipo'))
 fmt_dep  = dependency(
   'fmt',
   cmake_args: get_option('fmt')!='' ? '-DCMAKE_PREFIX_PATH='+get_option('fmt') : '',
 )
-hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: '-DCMAKE_PREFIX_PATH=' + get_option('hipo'))
 
 subdir('src/services')
 subdir('src/algorithms')

--- a/meson.build
+++ b/meson.build
@@ -15,15 +15,11 @@ dep_lib_rpaths = [
 '$ORIGIN/../' + project_lib_install_dir,
   get_option('hipo') + '/lib',
 ]
-cmake_prefix_paths = [
-  get_option('hipo'),
-]
 
 project_lib_rpath = '$ORIGIN'
 project_bin_rpath = ':'.join(dep_lib_rpaths)
-cmake_prefix_path = '-DCMAKE_PREFIX_PATH=' + ';'.join(cmake_prefix_paths)
 
-hipo_dep = dependency('hipo4', method: 'cmake', cmake_args: cmake_prefix_path)
+hipo_dep = dependency('hipo4')
 fmt_dep  = dependency('fmt')
 
 subdir('src/services')

--- a/meson.build
+++ b/meson.build
@@ -8,10 +8,7 @@ project(
 
 project_inc = include_directories('src')
 
-project_lib_install_dir = 'lib' # to keep it the same for different Linux distributions
-project_bin_install_dir = 'bin'
-
-dep_lib_rpaths = [ '$ORIGIN/../' + project_lib_install_dir ]
+dep_lib_rpaths = [ get_option('prefix') + '/' + get_option('libdir') ]
 foreach path : get_option('cmake_prefix_path')
   dep_lib_rpaths += path + '/lib' # TODO: this adds hipo4 libs to the rpath; consider instead linking against hipo4 static lib
 endforeach

--- a/meson.options
+++ b/meson.options
@@ -1,1 +1,2 @@
 option('hipo', type: 'string', value: '/usr/local', description: 'HIPO installation location')
+option('fmt',  type: 'string', value: '',           description: 'fmt installation location')

--- a/meson.options
+++ b/meson.options
@@ -1,1 +1,0 @@
-option('hipo', type: 'string', value: '/usr/local', description: 'HIPO installation location')

--- a/meson.options
+++ b/meson.options
@@ -1,2 +1,1 @@
 option('hipo', type: 'string', value: '/usr/local', description: 'HIPO installation location')
-option('fmt',  type: 'string', value: '',           description: 'fmt installation location')

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -3,18 +3,26 @@
 namespace iguana::clas12 {
 
   EventBuilderFilter::EventBuilderFilter() : Algorithm("event_builder_filter") {
+
+    // define required banks
     m_requiredBanks = {
       "REC::Particle",
       "REC::Calorimeter"
     };
+
+    // set default configuration options
+    o_pids = {11, 211};
   }
 
   void EventBuilderFilter::Start(bank_index_cache_t &index_cache) {
 
-    // set configuration
+    // set logger
+    // TODO: should be done by configuration
     m_log->SetLevel(Logger::Level::trace);
     m_log->Debug("START {}", m_name);
-    m_opt.pids = {11, 211, -211};
+
+    // cache options
+    CacheOption("pids", o_pids);
 
     // cache expected bank indices
     CacheBankIndex(index_cache, b_particle, "REC::Particle");
@@ -48,7 +56,7 @@ namespace iguana::clas12 {
 
 
   bool EventBuilderFilter::Filter(int pid) {
-    return m_opt.pids.find(pid) != m_opt.pids.end();
+    return o_pids.find(pid) != o_pids.end();
   }
 
 

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -3,16 +3,13 @@
 namespace iguana::clas12 {
 
   EventBuilderFilter::EventBuilderFilter() : Algorithm("event_builder_filter") {
+
     // define required banks
     m_requiredBanks = { "REC::Particle", "REC::Calorimeter" }; // TODO: remove calorimeter
+
   }
 
   void EventBuilderFilter::Start(bank_index_cache_t &index_cache) {
-
-    // set logger
-    // TODO: should be done by configuration and BEFORE Start(), so `SetOption()` will print the user's options
-    m_log->SetLevel(Logger::Level::trace);
-    m_log->Debug("START {}", m_name);
 
     // define options, their default values, and cache them
     CacheOption("pids", std::set<int>{11, 211}, o_pids);
@@ -27,7 +24,6 @@ namespace iguana::clas12 {
 
 
   void EventBuilderFilter::Run(bank_vec_t banks) {
-    m_log->Debug("RUN {}", m_name);
 
     // get the banks
     auto particleBank = GetBank(banks, b_particle, "REC::Particle");
@@ -56,7 +52,6 @@ namespace iguana::clas12 {
 
 
   void EventBuilderFilter::Stop() {
-    m_log->Debug("STOP {}", m_name);
   }
 
 }

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -10,7 +10,7 @@ namespace iguana::clas12 {
   void EventBuilderFilter::Start(bank_index_cache_t &index_cache) {
 
     // set logger
-    // TODO: should be done by configuration
+    // TODO: should be done by configuration and BEFORE Start(), so `SetOption()` will print the user's options
     m_log->SetLevel(Logger::Level::trace);
     m_log->Debug("START {}", m_name);
 

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -3,15 +3,8 @@
 namespace iguana::clas12 {
 
   EventBuilderFilter::EventBuilderFilter() : Algorithm("event_builder_filter") {
-
     // define required banks
-    m_requiredBanks = {
-      "REC::Particle",
-      "REC::Calorimeter"
-    };
-
-    // set default configuration options
-    SetOption("pids", std::set<int>{11, 211});
+    m_requiredBanks = { "REC::Particle", "REC::Calorimeter" };
   }
 
   void EventBuilderFilter::Start(bank_index_cache_t &index_cache) {
@@ -21,9 +14,8 @@ namespace iguana::clas12 {
     m_log->SetLevel(Logger::Level::trace);
     m_log->Debug("START {}", m_name);
 
-    // cache options
-    CacheOption("pids", o_pids);
-    PrintOptions();
+    // cache options and define their defaults
+    CacheOption("pids", std::set<int>{11, 211}, o_pids);
 
     // cache expected bank indices
     CacheBankIndex(index_cache, b_particle, "REC::Particle");

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -11,7 +11,7 @@ namespace iguana::clas12 {
     };
 
     // set default configuration options
-    o_pids = {11, 211};
+    SetOption("pids", std::set<int>{11, 211});
   }
 
   void EventBuilderFilter::Start(bank_index_cache_t &index_cache) {
@@ -23,6 +23,7 @@ namespace iguana::clas12 {
 
     // cache options
     CacheOption("pids", o_pids);
+    PrintOptions();
 
     // cache expected bank indices
     CacheBankIndex(index_cache, b_particle, "REC::Particle");

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -4,7 +4,7 @@ namespace iguana::clas12 {
 
   EventBuilderFilter::EventBuilderFilter() : Algorithm("event_builder_filter") {
     // define required banks
-    m_requiredBanks = { "REC::Particle", "REC::Calorimeter" };
+    m_requiredBanks = { "REC::Particle", "REC::Calorimeter" }; // TODO: remove calorimeter
   }
 
   void EventBuilderFilter::Start(bank_index_cache_t &index_cache) {
@@ -14,12 +14,14 @@ namespace iguana::clas12 {
     m_log->SetLevel(Logger::Level::trace);
     m_log->Debug("START {}", m_name);
 
-    // cache options and define their defaults
+    // define options, their default values, and cache them
     CacheOption("pids", std::set<int>{11, 211}, o_pids);
+    CacheOption("testInt", 8, o_testInt); // TODO: remove
+    CacheOption("testFloat", 7.0, o_testFloat); // TODO: remove
 
     // cache expected bank indices
     CacheBankIndex(index_cache, b_particle, "REC::Particle");
-    CacheBankIndex(index_cache, b_calo,     "REC::Calorimeter");
+    CacheBankIndex(index_cache, b_calo,     "REC::Calorimeter"); // TODO: remove
 
   }
 
@@ -29,7 +31,7 @@ namespace iguana::clas12 {
 
     // get the banks
     auto particleBank = GetBank(banks, b_particle, "REC::Particle");
-    auto caloBank     = GetBank(banks, b_calo,     "REC::Calorimeter");
+    auto caloBank     = GetBank(banks, b_calo,     "REC::Calorimeter"); // TODO: remove
 
     // dump the bank
     ShowBank(particleBank, Logger::Header("INPUT PARTICLES"));

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -52,6 +52,9 @@ namespace iguana::clas12 {
 
 
   void EventBuilderFilter::Stop() {
+    m_log->Info("test info");
+    m_log->Warn("test warn");
+    m_log->Error("test error");
   }
 
 }

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
@@ -21,10 +21,12 @@ namespace iguana::clas12 {
     private:
 
       /// `bank_vec_t` indices
-      int b_particle, b_calo;
+      int b_particle, b_calo; // TODO: remove calorimeter
 
       /// configuration options
       std::set<int> o_pids;
+      int o_testInt; // TODO: remove
+      double o_testFloat; // TODO: remove
 
   };
 

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
@@ -5,12 +5,6 @@
 
 namespace iguana::clas12 {
 
-  class EventBuilderFilterOptions {
-    public:
-      std::set<int> pids = {11, 211};
-  };
-
-
   class EventBuilderFilter : public Algorithm {
 
     public:
@@ -25,8 +19,12 @@ namespace iguana::clas12 {
       bool Filter(int pid);
 
     private:
-      EventBuilderFilterOptions m_opt;
+
+      /// `bank_vec_t` indices
       int b_particle, b_calo;
+
+      /// configuration options
+      std::set<int> o_pids;
 
   };
 

--- a/src/algorithms/meson.build
+++ b/src/algorithms/meson.build
@@ -13,7 +13,6 @@ algo_lib = shared_library(
   dependencies:        services_dep,
   link_with:           services_lib,
   install:             true,
-  install_dir:         project_lib_install_dir,
   install_rpath:       project_lib_rpath,
 )
 

--- a/src/iguana/meson.build
+++ b/src/iguana/meson.build
@@ -13,7 +13,6 @@ iguana_lib = shared_library(
   dependencies:        [ fmt_dep, hipo_dep ],
   link_with:           [ algo_lib, services_lib ],
   install:             true,
-  install_dir:         project_lib_install_dir,
   install_rpath:       project_lib_rpath,
 )
 

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -14,6 +14,26 @@ namespace iguana {
     Start(index_cache);
   }
 
+  void Algorithm::SetOption(std::string key, option_value_t val) {
+    m_opt[key] = val;
+  }
+
+  void Algorithm::PrintOptions(Logger::Level level) {
+    if(m_log->GetLevel() <= level) {
+      m_log->Print(level, Logger::Header("CONFIGURATION OPTIONS"));
+      std::string format_str = "{:>20} = {}   [{}]";
+      for(auto [key, val] : m_opt) {
+        if      (const auto valPtr(std::get_if<int>(&val));           valPtr) m_log->Print(level, format_str, key, *valPtr,                 "int");
+        else if (const auto valPtr(std::get_if<double>(&val));        valPtr) m_log->Print(level, format_str, key, *valPtr,                 "double");
+        else if (const auto valPtr(std::get_if<std::string>(&val));   valPtr) m_log->Print(level, format_str, key, *valPtr,                 "string");
+        else if (const auto valPtr(std::get_if<std::set<int>>(&val)); valPtr) m_log->Print(level, format_str, key, fmt::join(*valPtr,", "), "set<int>");
+        else
+          m_log->Error("option '{}' type has no printer defined in PrintOptions", key);
+      }
+      m_log->Print(level, Logger::Header(""));
+    }
+  }
+
   void Algorithm::CacheBankIndex(bank_index_cache_t index_cache, int &idx, std::string bankName) {
     try {
       idx = index_cache.at(bankName);

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -19,6 +19,14 @@ namespace iguana {
     m_log->Debug("User set option '{}' = {}", key, PrintOptionValue(key));
   }
 
+  void Algorithm::SetLogLevel(std::string level) {
+    m_log->SetLevel(level);
+  }
+
+  void Algorithm::SetLogLevel(Logger::Level level) {
+    m_log->SetLevel(level);
+  }
+
   void Algorithm::CacheBankIndex(bank_index_cache_t index_cache, int &idx, std::string bankName) {
     try {
       idx = index_cache.at(bankName);

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -18,22 +18,6 @@ namespace iguana {
     m_opt[key] = val;
   }
 
-  void Algorithm::PrintOptions(Logger::Level level) {
-    if(m_log->GetLevel() <= level) {
-      m_log->Print(level, Logger::Header("CONFIGURATION OPTIONS"));
-      std::string format_str = "{:>20} = {}   [{}]";
-      for(auto [key, val] : m_opt) {
-        if      (const auto valPtr(std::get_if<int>(&val));           valPtr) m_log->Print(level, format_str, key, *valPtr,                 "int");
-        else if (const auto valPtr(std::get_if<double>(&val));        valPtr) m_log->Print(level, format_str, key, *valPtr,                 "double");
-        else if (const auto valPtr(std::get_if<std::string>(&val));   valPtr) m_log->Print(level, format_str, key, *valPtr,                 "string");
-        else if (const auto valPtr(std::get_if<std::set<int>>(&val)); valPtr) m_log->Print(level, format_str, key, fmt::join(*valPtr,", "), "set<int>");
-        else
-          m_log->Error("option '{}' type has no printer defined in PrintOptions", key);
-      }
-      m_log->Print(level, Logger::Header(""));
-    }
-  }
-
   void Algorithm::CacheBankIndex(bank_index_cache_t index_cache, int &idx, std::string bankName) {
     try {
       idx = index_cache.at(bankName);

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -19,12 +19,8 @@ namespace iguana {
     m_log->Debug("User set option '{}' = {}", key, PrintOptionValue(key));
   }
 
-  void Algorithm::SetLogLevel(std::string level) {
-    m_log->SetLevel(level);
-  }
-
-  void Algorithm::SetLogLevel(Logger::Level level) {
-    m_log->SetLevel(level);
+  std::shared_ptr<Logger> Algorithm::Log() {
+    return m_log;
   }
 
   void Algorithm::CacheBankIndex(bank_index_cache_t index_cache, int &idx, std::string bankName) {

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -16,6 +16,7 @@ namespace iguana {
 
   void Algorithm::SetOption(std::string key, option_value_t val) {
     m_opt[key] = val;
+    m_log->Debug("User set option '{}' = {}", key, PrintOptionValue(key));
   }
 
   void Algorithm::CacheBankIndex(bank_index_cache_t index_cache, int &idx, std::string bankName) {
@@ -25,6 +26,24 @@ namespace iguana {
       Throw(fmt::format("required input bank '{}' not found; cannot `Start` algorithm '{}'", bankName, m_name));
     }
     m_log->Debug("cached index of bank '{}' is {}", bankName, idx);
+  }
+
+  std::string Algorithm::PrintOptionValue(std::string key) {
+    if(auto it{m_opt.find(key)}; it != m_opt.end()) {
+      auto val = it->second;
+      std::string format_str = "{} [{}]";
+      if      (const auto valPtr(std::get_if<int>(&val));           valPtr) return fmt::format("{} [{}]", *valPtr,                 "int");
+      else if (const auto valPtr(std::get_if<double>(&val));        valPtr) return fmt::format("{} [{}]", *valPtr,                 "double");
+      else if (const auto valPtr(std::get_if<std::string>(&val));   valPtr) return fmt::format("{} [{}]", *valPtr,                 "string");
+      else if (const auto valPtr(std::get_if<std::set<int>>(&val)); valPtr) return fmt::format("({}) [{}]", fmt::join(*valPtr,", "), "set<int>");
+      else {
+        m_log->Error("option '{}' type has no printer defined in Algorithm::PrintOptionValue", key);
+        return "UNKNOWN";
+      }
+    }
+    else
+      m_log->Error("option '{}' not found by Algorithm::PrintOptionValue", key);
+    return "UNKNOWN";
   }
 
   bank_ptr Algorithm::GetBank(bank_vec_t banks, int idx, std::string expectedBankName) {

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -31,6 +31,11 @@ namespace iguana {
       /// Finalize an algorithm after all events are processed
       virtual void Stop() = 0;
 
+      /// Set an option specified by the user
+      /// @param key the name of the option
+      /// @param val the value to set
+      void SetOption(std::string key, option_value_t val);
+
     protected:
 
       /// Cache the index of a bank in a `bank_vec_t`; throws an exception if the bank is not found
@@ -38,6 +43,17 @@ namespace iguana {
       /// @param idx a reference to the `bank_vec_t` index of the bank
       /// @param bankName the name of the bank
       void CacheBankIndex(bank_index_cache_t index_cache, int &idx, std::string bankName);
+
+      /// Cache an option specified by the user
+      /// @param key the name of the option
+      /// @param val reference to the value of the option
+      template <typename VALUE>
+        void CacheOption(std::string key, VALUE &val) {
+          if(auto it{m_opt.find(key)}; it != m_opt.end())
+            val = it->second;
+          else
+            m_log->Warn("unknown option '{}' in SetOption", key);
+        }
 
       /// Get the pointer to a bank from a `bank_vec_t`; optionally checks if the bank name matches the expectation
       /// @param banks the `bank_vec_t` from which to get the specified bank
@@ -81,5 +97,8 @@ namespace iguana {
 
       /// Logger
       std::shared_ptr<Logger> m_log;
+
+      /// Configuration options
+      options_t m_opt;
   };
 }

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -36,13 +36,9 @@ namespace iguana {
       /// @param val the value to set
       void SetOption(std::string key, option_value_t val);
 
-      /// Set the log level
-      /// @param level the log level name
-      void SetLogLevel(std::string level);
-
-      /// Set the log level
-      /// @param level the log level number
-      void SetLogLevel(Logger::Level level);
+      /// Get the logger
+      /// @return the logger used by this algorithm
+      std::shared_ptr<Logger> Log();
 
     protected:
 

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -36,6 +36,10 @@ namespace iguana {
       /// @param val the value to set
       void SetOption(std::string key, option_value_t val);
 
+      /// Print all the options and their values for this algorithm
+      /// @param level the log level
+      void PrintOptions(Logger::Level level=Logger::debug);
+
     protected:
 
       /// Cache the index of a bank in a `bank_vec_t`; throws an exception if the bank is not found
@@ -50,9 +54,9 @@ namespace iguana {
       template <typename VALUE>
         void CacheOption(std::string key, VALUE &val) {
           if(auto it{m_opt.find(key)}; it != m_opt.end())
-            val = it->second;
+            val = std::get<VALUE>(it->second);
           else
-            m_log->Warn("unknown option '{}' in SetOption", key);
+            m_log->Warn("unknown option '{}' in CacheOption", key);
         }
 
       /// Get the pointer to a bank from a `bank_vec_t`; optionally checks if the bank name matches the expectation

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -36,6 +36,14 @@ namespace iguana {
       /// @param val the value to set
       void SetOption(std::string key, option_value_t val);
 
+      /// Set the log level
+      /// @param level the log level name
+      void SetLogLevel(std::string level);
+
+      /// Set the log level
+      /// @param level the log level number
+      void SetLogLevel(Logger::Level level);
+
     protected:
 
       /// Cache the index of a bank in a `bank_vec_t`; throws an exception if the bank is not found

--- a/src/services/Logger.cc
+++ b/src/services/Logger.cc
@@ -23,7 +23,7 @@ namespace iguana {
   }
 
   std::string Logger::Header(std::string message, int width) {
-    return fmt::format("{:=^{}}", message, width);
+    return fmt::format("{:=^{}}", " " + message + " ", width);
   }
 
 }

--- a/src/services/Logger.cc
+++ b/src/services/Logger.cc
@@ -13,9 +13,19 @@ namespace iguana {
     SetLevel(lev);
   }
 
+  void Logger::SetLevel(std::string lev) {
+    for(auto &[lev_i, lev_n] : m_level_names) {
+      if(lev == lev_n) {
+        SetLevel(lev_i);
+        return;
+      }
+    }
+    Error("Log level '{}' is not a known log level; the log level will remain at '{}'", lev, m_level_names.at(m_level));
+  }
+
   void Logger::SetLevel(Level lev) {
     m_level = lev;
-    Debug("Logger '{}' set to '{}'", m_name, m_level_names.at(m_level));
+    Debug("log level set to '{}'", m_level_names.at(m_level));
   }
 
   Logger::Level Logger::GetLevel() {

--- a/src/services/Logger.cc
+++ b/src/services/Logger.cc
@@ -2,7 +2,7 @@
 
 namespace iguana {
 
-  Logger::Logger(std::string name, Level lev) : m_name(name) {
+  Logger::Logger(std::string name, Level lev, bool enable_style) : m_name(name), m_enable_style(enable_style) {
     m_level_names = {
       { trace, "trace" },
       { debug, "debug" },

--- a/src/services/Logger.h
+++ b/src/services/Logger.h
@@ -22,7 +22,9 @@ namespace iguana {
       Logger(std::string name = "log", Level lev = defaultLevel);
       ~Logger() {}
 
+      void SetLevel(std::string lev);
       void SetLevel(Level lev);
+
       Level GetLevel();
       static std::string Header(std::string message, int width=50);
 

--- a/src/services/TypeDefs.h
+++ b/src/services/TypeDefs.h
@@ -1,6 +1,8 @@
 #include <memory>
 #include <vector>
+#include <set>
 #include <unordered_map>
+#include <variant>
 
 #include <hipo4/bank.h>
 
@@ -14,5 +16,16 @@ namespace iguana {
 
   /// association between HIPO bank name and its index in a `bank_vec_t`
   using bank_index_cache_t = std::unordered_map<std::string, int>;
+
+  /// option value variant type
+  using option_value_t = std::variant<
+    int,
+    double,
+    std::string,
+    std::set<int>
+  >
+
+  /// data structure to hold configuration options
+  using options_t = std::unordered_map<std::string, option_value_t>
 
 }

--- a/src/services/TypeDefs.h
+++ b/src/services/TypeDefs.h
@@ -23,9 +23,9 @@ namespace iguana {
     double,
     std::string,
     std::set<int>
-  >
+  >;
 
   /// data structure to hold configuration options
-  using options_t = std::unordered_map<std::string, option_value_t>
+  using options_t = std::unordered_map<std::string, option_value_t>;
 
 }

--- a/src/services/meson.build
+++ b/src/services/meson.build
@@ -15,7 +15,6 @@ services_lib = shared_library(
   include_directories: project_inc,
   dependencies:        [ fmt_dep, hipo_dep ],
   install:             true,
-  install_dir:         project_lib_install_dir,
   install_rpath:       project_lib_rpath,
 )
 

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -4,7 +4,7 @@ foreach test_exe : [ 'run_banks', 'run_rows' ]
     test_exe + '.cc',
     include_directories: project_inc,
     dependencies:        [ fmt_dep, hipo_dep ],
-    link_with:           [ iguana_lib, algo_lib ],
+    link_with:           [ iguana_lib, algo_lib, services_lib ],
     install:             true,
     install_dir:         project_bin_install_dir,
     install_rpath:       project_bin_rpath,

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -6,7 +6,6 @@ foreach test_exe : [ 'run_banks', 'run_rows' ]
     dependencies:        [ fmt_dep, hipo_dep ],
     link_with:           [ iguana_lib, algo_lib, services_lib ],
     install:             true,
-    install_dir:         project_bin_install_dir,
     install_rpath:       project_bin_rpath,
   )
 endforeach

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -22,6 +22,8 @@ int main(int argc, char **argv) {
   iguana::Iguana I;
   auto algo = I.algo_map.at(iguana::Iguana::clas12_EventBuilderFilter);
   algo->SetOption("pids", std::set<int>{11, 211, -211});
+  algo->SetOption("testInt", 3);
+  algo->SetOption("testFloat", 11.0);
   algo->Start();
 
   /////////////////////////////////////////////////////

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
    */
   iguana::Iguana I;
   auto algo = I.algo_map.at(iguana::Iguana::clas12_EventBuilderFilter);
-  algo->SetOption("pids", {11, 211, -211});
+  algo->SetOption("pids", std::set<int>{11, 211, -211});
   algo->Start();
 
   /////////////////////////////////////////////////////

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -21,7 +21,8 @@ int main(int argc, char **argv) {
    */
   iguana::Iguana I;
   auto algo = I.algo_map.at(iguana::Iguana::clas12_EventBuilderFilter);
-  algo->SetLogLevel("trace");
+  algo->Log()->SetLevel("trace");
+  // algo->Log()->DisableStyle();
   algo->SetOption("pids", std::set<int>{11, 211, -211});
   algo->SetOption("testInt", 3);
   algo->SetOption("testFloat", 11.0);

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -21,6 +21,7 @@ int main(int argc, char **argv) {
    */
   iguana::Iguana I;
   auto algo = I.algo_map.at(iguana::Iguana::clas12_EventBuilderFilter);
+  algo->SetOption("pids", {11, 211, -211});
   algo->Start();
 
   /////////////////////////////////////////////////////

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -21,6 +21,7 @@ int main(int argc, char **argv) {
    */
   iguana::Iguana I;
   auto algo = I.algo_map.at(iguana::Iguana::clas12_EventBuilderFilter);
+  algo->SetLogLevel("trace");
   algo->SetOption("pids", std::set<int>{11, 211, -211});
   algo->SetOption("testInt", 3);
   algo->SetOption("testFloat", 11.0);

--- a/src/tests/run_rows.cc
+++ b/src/tests/run_rows.cc
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
 
   // start the algorithm
   auto algo = std::make_shared<iguana::clas12::EventBuilderFilter>();
-  algo->SetOption("pids", {11, 211, -211});
+  algo->SetOption("pids", std::set<int>{11, 211, -211});
   algo->Start();
 
   /////////////////////////////////////////////////////

--- a/src/tests/run_rows.cc
+++ b/src/tests/run_rows.cc
@@ -10,6 +10,7 @@ int main(int argc, char **argv) {
 
   // start the algorithm
   auto algo = std::make_shared<iguana::clas12::EventBuilderFilter>();
+  algo->SetOption("pids", {11, 211, -211});
   algo->Start();
 
   /////////////////////////////////////////////////////


### PR DESCRIPTION
The scope of this PR expanded beyond its original intent, and should actually separated into the following PRs:

### feat: configuration streamlining
- cache the option to avoid hashing in `Run`
- set default option values
- provide `SetOption` for the user
- provide `PrintOption` to dump options

### feat: colored log output
- `error` and `warn` log printouts are now colored
- enabled by default, and can be disabled by the user

### build: improved dependency resolution
- use built-in options for better user control