### PR TITLE
fix: python shebang `python`->`python3`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from configparser import ConfigParser
 import argparse, os, sys, textwrap


### PR DESCRIPTION
Some installations may still use `python` for v2, or may not even have `python` in `$PATH` and only have `python3`. Using `python3` in the shebang seems to be a common trend for v3 scripts.

Discussion here: https://stackoverflow.com/questions/64048813/what-shebang-should-i-use-to-consistently-point-to-python3
which includes a more robust solution using a "hybrid script" approach:
```python
#!/bin/bash
_='''' # Prefer python3 if it exists
command -v python3 &> /dev/null && exec python3 $0 "$@" || exec python $0 "$@"
'''
# Python code here
print ("Hello")
```

Let's use `python3` unless this becomes an issue.