### PR TITLE
fix: regress `hipo::bank::get` to `hipo::bank::get[TYPE]`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 env:
-  hipo_version: 94e2cfc1ab93388680ba07088d9b63b68347ba92 # before hipo::bank::get and put were removed
+  hipo_version: 380d54ec47086b31fe13e637329748b2df06ea84
   fmt_version: 9.1.0
 
 jobs:

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -34,10 +34,10 @@ namespace iguana::clas12 {
 
     // filter the input bank for requested PDG code(s)
     for(int row = 0; row < particleBank->getRows(); row++) {
-      auto pid    = particleBank->get("pid", row);
+      auto pid    = particleBank->getInt("pid", row);
       auto accept = Filter(pid);
       if(!accept)
-        BlankRow(particleBank, row);
+        MaskRow(particleBank, row);
       m_log->Debug("input PID {} -- accept = {}", pid, accept);
     }
 

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -63,10 +63,10 @@ namespace iguana {
     return result;
   }
 
-  void Algorithm::BlankRow(bank_ptr bank, int row) {
-    for(int item = 0; item < bank->getSchema().getEntries(); item++) {
-      bank->put(item, row, 0);
-    }
+  void Algorithm::MaskRow(bank_ptr bank, int row) {
+    // TODO: need https://github.com/gavalian/hipo/issues/35
+    // until then, just set the PID to -1
+    bank->putInt("pid", row, -1);
   }
 
   void Algorithm::ShowBanks(bank_vec_t banks, std::string message, Logger::Level level) {

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -86,10 +86,10 @@ namespace iguana {
       /// @return the modified `bank_vec_t`
       bank_ptr GetBank(bank_vec_t banks, int idx, std::string expectedBankName="");
 
-      /// Blank a row, setting all items to zero
+      /// Mask a row, setting all items to zero
       /// @param bank the bank to modify
       /// @param row the row to blank
-      void BlankRow(bank_ptr bank, int row);
+      void MaskRow(bank_ptr bank, int row);
 
       /// Dump all banks in a `bank_vec_t`
       /// @param banks the banks to show

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -4,7 +4,7 @@
 void printParticles(std::string prefix, iguana::bank_ptr b) {
   std::vector<int> pids;
   for(int row=0; row<b->getRows(); row++)
-    pids.push_back(b->get("pid", row));
+    pids.push_back(b->getInt("pid", row));
   fmt::print("{}: {}\n", prefix, fmt::join(pids, ", "));
 }
 

--- a/src/tests/run_rows.cc
+++ b/src/tests/run_rows.cc
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
     event.getStructure(*particleBank);
     fmt::print("PIDS FILTERED BY algo->Filter():\n");
     for(int row=0; row<particleBank->getRows(); row++) {
-      auto pid = particleBank->get("pid", row);
+      auto pid = particleBank->getInt("pid", row);
       fmt::print("{:>10}:{}\n", pid, algo->Filter(pid) ? " -- ACCEPT" : "");
     }
 


### PR DESCRIPTION
Since https://github.com/gavalian/hipo/pull/29 was reverted, we are forced to regress some usability here.

Instead of using upstream type inference via
```cpp
bank.get(...)
```
we must use one of
```
bank.getInt(...)
bank.getFloat(...)
// etc.
```
and know the data types at compile time (though the correct type is only verified upstream at runtime).