### PR TITLE
fix: enforce const correctness

### DIFF
--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -9,7 +9,7 @@ namespace iguana::clas12 {
 
   }
 
-  void EventBuilderFilter::Start(bank_index_cache_t& index_cache) {
+  void EventBuilderFilter::Start(const bank_index_cache_t& index_cache) {
 
     // define options, their default values, and cache them
     CacheOption("pids", std::set<int>{11, 211}, o_pids);
@@ -23,7 +23,7 @@ namespace iguana::clas12 {
   }
 
 
-  void EventBuilderFilter::Run(hipo::banklist& banks) {
+  void EventBuilderFilter::Run(hipo::banklist& banks) const {
 
     // get the banks
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
@@ -46,7 +46,7 @@ namespace iguana::clas12 {
   }
 
 
-  bool EventBuilderFilter::Filter(int pid) {
+  bool EventBuilderFilter::Filter(const int pid) const {
     return o_pids.find(pid) != o_pids.end();
   }
 

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
@@ -12,11 +12,11 @@ namespace iguana::clas12 {
       ~EventBuilderFilter() {}
 
       void Start() override { Algorithm::Start(); }
-      void Start(bank_index_cache_t& index_cache) override;
-      void Run(hipo::banklist& banks) override;
+      void Start(const bank_index_cache_t& index_cache) override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
-      bool Filter(int pid);
+      bool Filter(const int pid) const;
 
     private:
 

--- a/src/services/Algorithm.cc
+++ b/src/services/Algorithm.cc
@@ -2,7 +2,7 @@
 
 namespace iguana {
 
-  Algorithm::Algorithm(std::string name) : m_name(name) {
+  Algorithm::Algorithm(const std::string name) : m_name(name) {
     m_log = std::make_unique<Logger>(m_name);
   }
 
@@ -14,7 +14,7 @@ namespace iguana {
     Start(index_cache);
   }
 
-  void Algorithm::SetOption(std::string key, option_value_t val) {
+  void Algorithm::SetOption(const std::string key, const option_value_t val) {
     m_opt[key] = val;
     m_log->Debug("User set option '{}' = {}", key, PrintOptionValue(key));
   }
@@ -23,7 +23,7 @@ namespace iguana {
     return m_log;
   }
 
-  void Algorithm::CacheBankIndex(bank_index_cache_t index_cache, int& idx, std::string bankName) {
+  void Algorithm::CacheBankIndex(const bank_index_cache_t index_cache, int& idx, const std::string bankName) const {
     try {
       idx = index_cache.at(bankName);
     } catch(const std::out_of_range& o) {
@@ -32,7 +32,7 @@ namespace iguana {
     m_log->Debug("cached index of bank '{}' is {}", bankName, idx);
   }
 
-  std::string Algorithm::PrintOptionValue(std::string key) {
+  std::string Algorithm::PrintOptionValue(const std::string key) const {
     if(auto it{m_opt.find(key)}; it != m_opt.end()) {
       auto val = it->second;
       std::string format_str = "{} [{}]";
@@ -50,7 +50,7 @@ namespace iguana {
     return "UNKNOWN";
   }
 
-  hipo::bank& Algorithm::GetBank(hipo::banklist& banks, int idx, std::string expectedBankName) {
+  hipo::bank& Algorithm::GetBank(hipo::banklist& banks, const int idx, const std::string expectedBankName) const {
     try {
       auto& result = banks.at(idx);
       if(expectedBankName != "" && result.getSchema().getName() != expectedBankName) {
@@ -63,13 +63,13 @@ namespace iguana {
     throw std::runtime_error("GetBank failed"); // avoid `-Wreturn-type` warning
   }
 
-  void Algorithm::MaskRow(hipo::bank& bank, int row) {
+  void Algorithm::MaskRow(hipo::bank& bank, const int row) const {
     // TODO: need https://github.com/gavalian/hipo/issues/35
     // until then, just set the PID to -1
     bank.putInt("pid", row, -1);
   }
 
-  void Algorithm::ShowBanks(hipo::banklist& banks, std::string message, Logger::Level level) {
+  void Algorithm::ShowBanks(hipo::banklist& banks, const std::string message, const Logger::Level level) const {
     if(m_log->GetLevel() <= level) {
       if(message != "")
         m_log->Print(level, message);
@@ -78,7 +78,7 @@ namespace iguana {
     }
   }
 
-  void Algorithm::ShowBank(hipo::bank& bank, std::string message, Logger::Level level) {
+  void Algorithm::ShowBank(hipo::bank& bank, const std::string message, const Logger::Level level) const {
     if(m_log->GetLevel() <= level) {
       if(message != "")
         m_log->Print(level, message);
@@ -86,7 +86,7 @@ namespace iguana {
     }
   }
 
-  void Algorithm::Throw(std::string message) {
+  void Algorithm::Throw(const std::string message) const {
     m_log->Error("CRITICAL RUNTIME ERROR!");
     throw std::runtime_error(fmt::format("{}; Algorithm '{}' stopped!", message, m_name));
   }

--- a/src/services/Algorithm.h
+++ b/src/services/Algorithm.h
@@ -11,7 +11,7 @@ namespace iguana {
 
       /// Algorithm base class constructor
       /// @param name the unique name for a derived class instance
-      Algorithm(std::string name);
+      Algorithm(const std::string name);
 
       /// Algorithm base class destructor
       virtual ~Algorithm() {}
@@ -22,11 +22,11 @@ namespace iguana {
 
       /// Initialize an algorithm before any events are processed
       /// @param index_cache The `Run` method will use these indices to access banks
-      virtual void Start(bank_index_cache_t& index_cache) = 0;
+      virtual void Start(const bank_index_cache_t& index_cache) = 0;
 
       /// Run an algorithm
       /// @param banks the set of banks to process
-      virtual void Run(hipo::banklist& banks) = 0;
+      virtual void Run(hipo::banklist& banks) const = 0;
 
       /// Finalize an algorithm after all events are processed
       virtual void Stop() = 0;
@@ -34,7 +34,7 @@ namespace iguana {
       /// Set an option specified by the user
       /// @param key the name of the option
       /// @param val the value to set
-      void SetOption(std::string key, option_value_t val);
+      void SetOption(const std::string key, const option_value_t val);
 
       /// Get the logger
       /// @return the logger used by this algorithm
@@ -46,14 +46,14 @@ namespace iguana {
       /// @param index_cache the relation between bank name and `hipo::banklist` index
       /// @param idx a reference to the `hipo::banklist` index of the bank
       /// @param bankName the name of the bank
-      void CacheBankIndex(bank_index_cache_t index_cache, int& idx, std::string bankName) noexcept(false);
+      void CacheBankIndex(const bank_index_cache_t index_cache, int& idx, const std::string bankName) const noexcept(false);
 
       /// Cache an option specified by the user, and define its default value
       /// @param key the name of the option
       /// @param def the default value
       /// @param val reference to the value of the option, to be cached by `Start`
       template <typename OPTION_TYPE>
-        void CacheOption(std::string key, OPTION_TYPE def, OPTION_TYPE& val) {
+        void CacheOption(const std::string key, const OPTION_TYPE def, OPTION_TYPE& val) {
           bool get_error = false;
           if(auto it{m_opt.find(key)}; it != m_opt.end()) { // cache the user's option value
             try { // get the expected type
@@ -77,38 +77,38 @@ namespace iguana {
       /// Return a string with the value of an option along with its type
       /// @param key the name of the option
       /// @return the string value and its type
-      std::string PrintOptionValue(std::string key);
+      std::string PrintOptionValue(const std::string key) const;
 
       /// Get the pointer to a bank from a `hipo::banklist`; optionally checks if the bank name matches the expectation
       /// @param banks the `hipo::banklist` from which to get the specified bank
       /// @param idx the index of `banks` of the specified bank
       /// @param expectedBankName if specified, checks that the specified bank has this name
       /// @return the modified `hipo::banklist`
-      hipo::bank& GetBank(hipo::banklist& banks, int idx, std::string expectedBankName="") noexcept(false);
+      hipo::bank& GetBank(hipo::banklist& banks, const int idx, const std::string expectedBankName="") const noexcept(false);
 
       /// Mask a row, setting all items to zero
       /// @param bank the bank to modify
       /// @param row the row to blank
-      void MaskRow(hipo::bank& bank, int row);
+      void MaskRow(hipo::bank& bank, const int row) const;
 
       /// Dump all banks in a `hipo::banklist`
       /// @param banks the banks to show
       /// @param message optionally print a header message
       /// @param level the log level
-      void ShowBanks(hipo::banklist& banks, std::string message="", Logger::Level level=Logger::trace);
+      void ShowBanks(hipo::banklist& banks, const std::string message="", const Logger::Level level=Logger::trace) const;
 
       /// Dump a single bank
       /// @param bank the bank to show
       /// @param message optionally print a header message
       /// @param level the log level
-      void ShowBank(hipo::bank& bank, std::string message="", Logger::Level level=Logger::trace);
+      void ShowBank(hipo::bank& bank, const std::string message="", const Logger::Level level=Logger::trace) const;
 
       /// Stop the algorithm and throw a runtime exception
       /// @param message the error message
-      void Throw(std::string message) noexcept(false);
+      void Throw(const std::string message) const noexcept(false);
 
       /// algorithm name
-      std::string m_name;
+      const std::string m_name;
 
       /// list of required banks
       std::vector<std::string> m_requiredBanks;

--- a/src/services/Logger.cc
+++ b/src/services/Logger.cc
@@ -2,7 +2,7 @@
 
 namespace iguana {
 
-  Logger::Logger(std::string name, Level lev, bool enable_style) : m_name(name), m_enable_style(enable_style) {
+  Logger::Logger(const std::string name, const Level lev, const bool enable_style) : m_name(name), m_enable_style(enable_style) {
     m_level_names = {
       { trace, "trace" },
       { debug, "debug" },
@@ -13,7 +13,7 @@ namespace iguana {
     SetLevel(lev);
   }
 
-  void Logger::SetLevel(std::string lev) {
+  void Logger::SetLevel(const std::string lev) {
     for(auto& [lev_i, lev_n] : m_level_names) {
       if(lev == lev_n) {
         SetLevel(lev_i);
@@ -23,7 +23,7 @@ namespace iguana {
     Error("Log level '{}' is not a known log level; the log level will remain at '{}'", lev, m_level_names.at(m_level));
   }
 
-  void Logger::SetLevel(Level lev) {
+  void Logger::SetLevel(const Level lev) {
     m_level = lev;
     Debug("log level set to '{}'", m_level_names.at(m_level));
   }
@@ -32,7 +32,15 @@ namespace iguana {
     return m_level;
   }
 
-  std::string Logger::Header(std::string message, int width) {
+  void Logger::EnableStyle() {
+    m_enable_style = true;
+  }
+
+  void Logger::DisableStyle() {
+    m_enable_style = false;
+  }
+
+  std::string Logger::Header(const std::string message, const int width) {
     return fmt::format("{:=^{}}", " " + message + " ", width);
   }
 

--- a/src/services/Logger.h
+++ b/src/services/Logger.h
@@ -21,26 +21,27 @@ namespace iguana {
       };
       static const Level DEFAULT_LEVEL = info;
 
-      Logger(std::string name = "log", Level lev = DEFAULT_LEVEL, bool enable_style = true);
+      Logger(const std::string name = "log", const Level lev = DEFAULT_LEVEL, const bool enable_style = true);
       ~Logger() {}
 
-      void SetLevel(std::string lev);
-      void SetLevel(Level lev);
-
-      void EnableStyle() { m_enable_style = true; }
-      void DisableStyle() { m_enable_style = false; }
+      void SetLevel(const std::string lev);
+      void SetLevel(const Level lev);
 
       Level GetLevel();
-      static std::string Header(std::string message, int width=50);
 
-      template <typename... VALUES> void Trace(std::string message, VALUES... vals) { Print(trace, message, vals...); }
-      template <typename... VALUES> void Debug(std::string message, VALUES... vals) { Print(debug, message, vals...); }
-      template <typename... VALUES> void Info(std::string  message, VALUES... vals) { Print(info,  message, vals...); }
-      template <typename... VALUES> void Warn(std::string  message, VALUES... vals) { Print(warn,  message, vals...); }
-      template <typename... VALUES> void Error(std::string message, VALUES... vals) { Print(error, message, vals...); }
+      void EnableStyle();
+      void DisableStyle();
+
+      static std::string Header(const std::string message, const int width=50);
+
+      template <typename... VALUES> void Trace(const std::string message, const VALUES... vals) const { Print(trace, message, vals...); }
+      template <typename... VALUES> void Debug(const std::string message, const VALUES... vals) const { Print(debug, message, vals...); }
+      template <typename... VALUES> void Info(const std::string  message, const VALUES... vals) const { Print(info,  message, vals...); }
+      template <typename... VALUES> void Warn(const std::string  message, const VALUES... vals) const { Print(warn,  message, vals...); }
+      template <typename... VALUES> void Error(const std::string message, const VALUES... vals) const { Print(error, message, vals...); }
 
       template <typename... VALUES>
-        void Print(Level lev, std::string message, VALUES... vals) {
+        void Print(const Level lev, const std::string message, const VALUES... vals) const {
           if(lev >= m_level) {
             if(auto it{m_level_names.find(lev)}; it != m_level_names.end()) {
               std::string prefix;
@@ -66,7 +67,7 @@ namespace iguana {
         }
 
     private:
-      std::string m_name;
+      const std::string m_name;
       Level m_level;
       std::unordered_map<Level,std::string> m_level_names;
       bool m_enable_style;

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -1,7 +1,7 @@
 #include "iguana/Iguana.h"
 #include <hipo4/reader.h>
 
-void printParticles(std::string prefix, hipo::bank& b) {
+void printParticles(const std::string prefix, hipo::bank& b) {
   std::vector<int> pids;
   for(int row=0; row<b.getRows(); row++)
     pids.push_back(b.getInt("pid", row));
@@ -12,14 +12,14 @@ int main(int argc, char **argv) {
 
   // parse arguments
   int argi = 1;
-  std::string inFileName = argc > argi ? std::string(argv[argi++]) : "data.hipo";
-  int         numEvents  = argc > argi ? std::stoi(argv[argi++])   : 3;
+  const std::string inFileName = argc > argi ? std::string(argv[argi++]) : "data.hipo";
+  const int         numEvents  = argc > argi ? std::stoi(argv[argi++])   : 1;
 
   // start iguana
   /* TODO: will be similified when we have more sugar in `iguana::Iguana`; until then we
    * use the test algorithm directly
    */
-  iguana::Iguana I;
+  const iguana::Iguana I;
   auto& algo = I.algo_map.at(iguana::Iguana::clas12_EventBuilderFilter);
   algo->Log()->SetLevel("trace");
   // algo->Log()->DisableStyle();


### PR DESCRIPTION
We want to make sure that `Algorithm::Run` overrides do not mutate instance members, so let's make it a const-qualified function. This PR does this, along with enforcing const-correctness everywhere.