### PR TITLE
fix(build): re-run `meson setup` if it failed

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -68,13 +68,7 @@ with open(installScript, 'w') as fp:
     fp.write(textwrap.dedent(f'''\
     #!/bin/bash
     set -e
-
-    # setup
-    if [ ! -d {args.build} ]; then
-      meson setup --native-file {args.ini} {args.build} {sourceDir}
-    fi
-
-    # compile and install
+    meson setup --native-file {args.ini} {args.build} {sourceDir}
     meson install -C {args.build}
     '''))
 os.chmod(installScript, 0o744)


### PR DESCRIPTION
The generated `install-iguana.sh` script was not re-running the `meson setup` step if it failed *e.g.*, due to a missing dependency. This PR sets it to run `meson setup` always.

When a successfully configured buildsystem exists, `meson setup` will just let the user know, and even prints a helpful `run "meson setup --wipe"` message for the user. IIRC, older versions of `meson` would instead throw an error message, but we require a modern version here anyway.