### PR TITLE
feat: factory pattern with self-registration for algorithm creation

### DIFF
--- a/src/algorithms/AlgorithmFactory.cc
+++ b/src/algorithms/AlgorithmFactory.cc
@@ -12,7 +12,7 @@ namespace iguana {
     return false;
   }
 
-  std::unique_ptr<Algorithm> AlgorithmFactory::Create(const std::string& name) noexcept {
+  algo_t AlgorithmFactory::Create(const std::string& name) noexcept {
     if(auto it=s_creators.find(name); it!=s_creators.end())
       return it->second();
     return nullptr;

--- a/src/algorithms/AlgorithmFactory.cc
+++ b/src/algorithms/AlgorithmFactory.cc
@@ -1,0 +1,21 @@
+#include "AlgorithmFactory.h"
+
+namespace iguana {
+
+  std::unordered_map<std::string, AlgorithmFactory::algo_creator_t> AlgorithmFactory::s_creators;
+
+  bool AlgorithmFactory::Register(const std::string& name, algo_creator_t creator) noexcept {
+    if(auto it=s_creators.find(name); it==s_creators.end()) {
+      s_creators.insert({name, creator});
+      return true;
+    }
+    return false;
+  }
+
+  std::unique_ptr<Algorithm> AlgorithmFactory::Create(const std::string& name) noexcept {
+    if(auto it=s_creators.find(name); it!=s_creators.end())
+      return it->second();
+    return nullptr;
+  }
+
+}

--- a/src/algorithms/AlgorithmFactory.h
+++ b/src/algorithms/AlgorithmFactory.h
@@ -7,13 +7,16 @@
 
 namespace iguana {
 
+  /// Algorithm pointer type
+  using algo_t = std::unique_ptr<Algorithm>;
+
   /// @brief Factory to create an algorithm.
   class AlgorithmFactory {
 
     public:
 
       /// Algorithm creator function type
-      using algo_creator_t = std::unique_ptr<Algorithm>(*)();
+      using algo_creator_t = algo_t(*)();
 
       AlgorithmFactory() = delete;
 
@@ -24,7 +27,7 @@ namespace iguana {
 
       /// Create an algorithm.
       /// @param name the name of the algorithm, which was used as an argument in the `AlgorithmFactory::Register` call
-      static std::unique_ptr<Algorithm> Create(const std::string& name) noexcept;
+      static algo_t Create(const std::string& name) noexcept;
 
     private:
 

--- a/src/algorithms/AlgorithmFactory.h
+++ b/src/algorithms/AlgorithmFactory.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <memory>
-#include <unordered_map>
-
 #include "services/Algorithm.h"
 
 namespace iguana {
@@ -16,7 +13,7 @@ namespace iguana {
     public:
 
       /// Algorithm creator function type
-      using algo_creator_t = algo_t(*)();
+      using algo_creator_t = std::function<algo_t()>;
 
       AlgorithmFactory() = delete;
 

--- a/src/algorithms/AlgorithmFactory.h
+++ b/src/algorithms/AlgorithmFactory.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "services/Algorithm.h"
+
+namespace iguana {
+
+  /// @brief Factory to create an algorithm.
+  class AlgorithmFactory {
+
+    public:
+
+      /// Algorithm creator function type
+      using algo_creator_t = std::unique_ptr<Algorithm>(*)();
+
+      AlgorithmFactory() = delete;
+
+      /// Register an algorithm with a unique name. Algorithms register themselves by calling this function.
+      /// @param name the name of the algorithm (not equivalent to `Object::m_name`)
+      /// @param creator the creator function
+      static bool Register(const std::string& name, algo_creator_t creator) noexcept;
+
+      /// Create an algorithm.
+      /// @param name the name of the algorithm, which was used as an argument in the `AlgorithmFactory::Register` call
+      static std::unique_ptr<Algorithm> Create(const std::string& name) noexcept;
+
+    private:
+
+      /// Association between the algorithm names and their creators
+      static std::unordered_map<std::string, algo_creator_t> s_creators;
+
+  };
+}

--- a/src/algorithms/AlgorithmSequence.cc
+++ b/src/algorithms/AlgorithmSequence.cc
@@ -2,13 +2,13 @@
 
 namespace iguana {
 
-  void AlgorithmSequence::Add(const std::string class_name, const std::string user_name) {
+  void AlgorithmSequence::Add(const std::string class_name, const std::string instance_name) {
     auto algo = AlgorithmFactory::Create(class_name);
     if(algo==nullptr) {
       m_log->Error("algorithm '{}' does not exist", class_name);
       throw std::runtime_error("AlgorithmFactory cannot create non-existent algorithm");
     }
-    algo->SetName(user_name=="" ? class_name : user_name);
+    algo->SetName(instance_name=="" ? class_name : instance_name);
     Add(std::move(algo));
   }
 
@@ -23,8 +23,8 @@ namespace iguana {
     }
   }
 
-  void AlgorithmSequence::SetOption(const std::string algo, const std::string key, const option_t val) {
-    Get<Algorithm>(algo)->SetOption(key,val);
+  void AlgorithmSequence::SetOption(const std::string algo_name, const std::string key, const option_t val) {
+    Get<Algorithm>(algo_name)->SetOption(key,val);
   }
 
   void AlgorithmSequence::SetName(const std::string name) {

--- a/src/algorithms/AlgorithmSequence.cc
+++ b/src/algorithms/AlgorithmSequence.cc
@@ -8,7 +8,7 @@ namespace iguana {
       m_log->Error("algorithm '{}' does not exist", class_name);
       throw std::runtime_error("AlgorithmFactory cannot create non-existent algorithm");
     }
-    algo->SetName(user_name);
+    algo->SetName(user_name=="" ? class_name : user_name);
     Add(std::move(algo));
   }
 

--- a/src/algorithms/AlgorithmSequence.cc
+++ b/src/algorithms/AlgorithmSequence.cc
@@ -2,6 +2,16 @@
 
 namespace iguana {
 
+  void AlgorithmSequence::Add(const std::string class_name, const std::string user_name) {
+    auto algo = AlgorithmFactory::Create(class_name);
+    if(algo==nullptr) {
+      m_log->Error("algorithm '{}' does not exist", class_name);
+      throw std::runtime_error("AlgorithmFactory cannot create non-existent algorithm");
+    }
+    algo->SetName(user_name);
+    Add(std::move(algo));
+  }
+
   void AlgorithmSequence::Add(algo_t&& algo) {
     auto algoName = algo->GetName();
     m_algo_names.insert({algoName, m_sequence.size()});

--- a/src/algorithms/AlgorithmSequence.h
+++ b/src/algorithms/AlgorithmSequence.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "services/Algorithm.h"
+#include "algorithms/AlgorithmFactory.h"
 
 namespace iguana {
 
@@ -16,7 +17,17 @@ namespace iguana {
       AlgorithmSequence(const std::string name="seq") : Algorithm(name) {}
       ~AlgorithmSequence() {}
 
-      /// Add an algorithm to the sequence.
+      /// Create and add an algorithm to the sequence, by name.
+      ///
+      /// **Example**
+      /// @code
+      /// Add("iguana::MyAlgorithm", "my_algorithm_name");
+      /// @endcode
+      /// @param class_name the name of the algorithm class
+      /// @param user_name a user-specified unique name for this algorithm
+      void Add(const std::string class_name, const std::string user_name);
+
+      /// Create and add an algorithm to the sequence.
       ///
       /// **Example**
       /// @code
@@ -28,7 +39,7 @@ namespace iguana {
           Add(std::make_unique<ALGORITHM>(name));
         }
 
-      /// Add an algorithm to the sequence. The `AlgorithmSequence` instance will take ownership of the algorithm
+      /// Add an existing algorithm to the sequence. The `AlgorithmSequence` instance will take ownership of the algorithm
       /// (if it is an `lvalue`, you will have to `std::move` it).
       ///
       /// **Example**

--- a/src/algorithms/AlgorithmSequence.h
+++ b/src/algorithms/AlgorithmSequence.h
@@ -24,8 +24,8 @@ namespace iguana {
       /// Add("iguana::MyAlgorithm", "my_algorithm_name");
       /// @endcode
       /// @param class_name the name of the algorithm class
-      /// @param user_name a user-specified unique name for this algorithm
-      void Add(const std::string class_name, const std::string user_name);
+      /// @param user_name a user-specified unique name for this algorithm; if not specified, `class_name` will be used
+      void Add(const std::string class_name, const std::string user_name="");
 
       /// Create and add an algorithm to the sequence.
       ///

--- a/src/algorithms/AlgorithmSequence.h
+++ b/src/algorithms/AlgorithmSequence.h
@@ -5,9 +5,6 @@
 
 namespace iguana {
 
-  /// Algorithm pointer type
-  using algo_t = std::unique_ptr<Algorithm>;
-
   /// @brief User-level class for running a sequence of algorithms
   class AlgorithmSequence : public Algorithm {
 
@@ -24,8 +21,9 @@ namespace iguana {
       /// Add("iguana::MyAlgorithm", "my_algorithm_name");
       /// @endcode
       /// @param class_name the name of the algorithm class
-      /// @param user_name a user-specified unique name for this algorithm; if not specified, `class_name` will be used
-      void Add(const std::string class_name, const std::string user_name="");
+      /// @param instance_name a user-specified unique name for this algorithm instance;
+      ///        if not specified, `class_name` will be used
+      void Add(const std::string class_name, const std::string instance_name="");
 
       /// Create and add an algorithm to the sequence.
       ///
@@ -33,10 +31,14 @@ namespace iguana {
       /// @code
       /// Add<iguana::MyAlgorithm>("my_algorithm_name");
       /// @endcode
-      /// @param name the name of the algorithm
+      /// @param instance_name a user-specified unique name for this algorithm instance;
+      ///        if not specified, the class name will be used
       template <class ALGORITHM>
-        void Add(const std::string name) {
-          Add(std::make_unique<ALGORITHM>(name));
+        void Add(const std::string instance_name="") {
+          if(instance_name=="")
+            Add(std::make_unique<ALGORITHM>());
+          else
+            Add(std::make_unique<ALGORITHM>(instance_name));
         }
 
       /// Add an existing algorithm to the sequence. The `AlgorithmSequence` instance will take ownership of the algorithm
@@ -49,28 +51,28 @@ namespace iguana {
       /// @param algo the algorithm
       void Add(algo_t&& algo);
 
-      /// Get an algorithm by name
+      /// Get an algorithm by its instance name
       ///
       /// **Example**
       /// @code
       /// Get<iguana::MyAlgorithm>("my_algorithm_name");
       /// @endcode
-      /// @param name the name of the algorithm
+      /// @param instance_name the instance name of the algorithm
       /// @return a reference to the algorithm
       template <class ALGORITHM>
-        ALGORITHM* Get(const std::string name) {
-          if(auto it{m_algo_names.find(name)}; it != m_algo_names.end())
+        ALGORITHM* Get(const std::string instance_name) {
+          if(auto it{m_algo_names.find(instance_name)}; it != m_algo_names.end())
             return dynamic_cast<ALGORITHM*>(m_sequence[it->second].get());
-          m_log->Error("cannot find algorithm '{}' in sequence", name);
+          m_log->Error("cannot find algorithm '{}' in sequence", instance_name);
           throw std::runtime_error("cannot Get algorithm");
         }
 
       /// Set an algorithm option
       /// @see `Algorithm::SetOption`
-      /// @param algo the algorithm name
+      /// @param algo_name the algorithm instance name
       /// @param key the option name
       /// @param val the option value
-      void SetOption(const std::string algo, const std::string key, const option_t val);
+      void SetOption(const std::string algo_name, const std::string key, const option_t val);
 
       /// Set the name of this sequence
       /// @param name the new name

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -3,7 +3,7 @@
 namespace iguana::clas12 {
 
   bool EventBuilderFilter::s_registered = AlgorithmFactory::Register(
-      "clas12::EventBuilderFilter",
+      EventBuilderFilter::ClassName(),
       EventBuilderFilter::Creator
       );
 

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.cc
@@ -2,6 +2,12 @@
 
 namespace iguana::clas12 {
 
+  bool EventBuilderFilter::s_registered = AlgorithmFactory::Register(
+      "clas12::EventBuilderFilter",
+      EventBuilderFilter::Creator
+      );
+
+
   void EventBuilderFilter::Start(hipo::banklist& banks) {
 
     // define options, their default values, and cache them

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "services/Algorithm.h"
+#include "algorithms/AlgorithmFactory.h"
 
 namespace iguana::clas12 {
 
@@ -12,6 +13,8 @@ namespace iguana::clas12 {
       /// @see `Algorithm::Algorithm`
       EventBuilderFilter(std::string name="event_builder_filter") : Algorithm(name) {}
       ~EventBuilderFilter() {}
+      /// Create an instance of this algorithm. This is used by `AlgorithmFactory`.
+      static std::unique_ptr<Algorithm> Creator() { return std::make_unique<EventBuilderFilter>(); }
 
       void Start(hipo::banklist& banks) override;
       void Run(hipo::banklist& banks) const override;
@@ -23,6 +26,9 @@ namespace iguana::clas12 {
       bool Filter(const int pid) const;
 
     private:
+
+      /// True if this algorithm is registered in `AlgorithmFactory`
+      static bool s_registered;
 
       /// `hipo::banklist` index for the particle bank
       hipo::banklist::size_type b_particle, b_calo; // TODO: remove calorimeter

--- a/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
+++ b/src/algorithms/clas12/event_builder_filter/EventBuilderFilter.h
@@ -11,10 +11,12 @@ namespace iguana::clas12 {
     public:
 
       /// @see `Algorithm::Algorithm`
-      EventBuilderFilter(std::string name="event_builder_filter") : Algorithm(name) {}
+      EventBuilderFilter(std::string name="") : Algorithm(name=="" ? ClassName() : name) {}
       ~EventBuilderFilter() {}
-      /// Create an instance of this algorithm. This is used by `AlgorithmFactory`.
-      static std::unique_ptr<Algorithm> Creator() { return std::make_unique<EventBuilderFilter>(); }
+      /// @returns An instance of this algorithm. This is used by `AlgorithmFactory`.
+      static algo_t Creator() { return std::make_unique<EventBuilderFilter>(); }
+      /// @returns This algorithm's class name
+      static std::string ClassName() { return "clas12::EventBuilderFilter"; }
 
       void Start(hipo::banklist& banks) override;
       void Run(hipo::banklist& banks) const override;

--- a/src/algorithms/clas12/lorentz_transformer/LorentzTransformer.cc
+++ b/src/algorithms/clas12/lorentz_transformer/LorentzTransformer.cc
@@ -3,7 +3,7 @@
 namespace iguana::clas12 {
 
   bool LorentzTransformer::s_registered = AlgorithmFactory::Register(
-      "clas12::LorentzTransformer",
+      LorentzTransformer::ClassName(),
       LorentzTransformer::Creator
       );
 

--- a/src/algorithms/clas12/lorentz_transformer/LorentzTransformer.cc
+++ b/src/algorithms/clas12/lorentz_transformer/LorentzTransformer.cc
@@ -2,6 +2,12 @@
 
 namespace iguana::clas12 {
 
+  bool LorentzTransformer::s_registered = AlgorithmFactory::Register(
+      "clas12::LorentzTransformer",
+      LorentzTransformer::Creator
+      );
+
+
   void LorentzTransformer::Start(hipo::banklist& banks) {
 
     CacheOption("frame", std::string{"mirror"}, o_frame);

--- a/src/algorithms/clas12/lorentz_transformer/LorentzTransformer.h
+++ b/src/algorithms/clas12/lorentz_transformer/LorentzTransformer.h
@@ -14,10 +14,12 @@ namespace iguana::clas12 {
     public:
 
       /// @see `Algorithm::Algorithm`
-      LorentzTransformer(std::string name="lorentz_transformer") : Algorithm(name) {}
+      LorentzTransformer(std::string name="") : Algorithm(name=="" ? ClassName() : name) {}
       ~LorentzTransformer() {}
-      /// Create an instance of this algorithm. This is used by `AlgorithmFactory`.
-      static std::unique_ptr<Algorithm> Creator() { return std::make_unique<LorentzTransformer>(); }
+      /// @returns An instance of this algorithm. This is used by `AlgorithmFactory`.
+      static algo_t Creator() { return std::make_unique<LorentzTransformer>(); }
+      /// @returns This algorithm's class name
+      static std::string ClassName() { return "clas12::LorentzTransformer"; }
 
       void Start(hipo::banklist& banks) override;
       void Run(hipo::banklist& banks) const override;

--- a/src/algorithms/clas12/lorentz_transformer/LorentzTransformer.h
+++ b/src/algorithms/clas12/lorentz_transformer/LorentzTransformer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "services/Algorithm.h"
+#include "algorithms/AlgorithmFactory.h"
 
 namespace iguana::clas12 {
 
@@ -15,6 +16,8 @@ namespace iguana::clas12 {
       /// @see `Algorithm::Algorithm`
       LorentzTransformer(std::string name="lorentz_transformer") : Algorithm(name) {}
       ~LorentzTransformer() {}
+      /// Create an instance of this algorithm. This is used by `AlgorithmFactory`.
+      static std::unique_ptr<Algorithm> Creator() { return std::make_unique<LorentzTransformer>(); }
 
       void Start(hipo::banklist& banks) override;
       void Run(hipo::banklist& banks) const override;
@@ -28,6 +31,9 @@ namespace iguana::clas12 {
       void Transform(float& px, float& py, float& pz, float& e) const;
 
     private:
+
+      /// True if this algorithm is registered in `AlgorithmFactory`
+      static bool s_registered;
 
       /// `hipo::banklist` index for the particle bank
       hipo::banklist::size_type b_particle;

--- a/src/algorithms/meson.build
+++ b/src/algorithms/meson.build
@@ -1,10 +1,12 @@
 algo_headers = [
+  'AlgorithmFactory.h',
   'clas12/event_builder_filter/EventBuilderFilter.h',
   'clas12/lorentz_transformer/LorentzTransformer.h',
   'AlgorithmSequence.h',
 ]
 
 algo_sources = [
+  'AlgorithmFactory.cc',
   'clas12/event_builder_filter/EventBuilderFilter.cc',
   'clas12/lorentz_transformer/LorentzTransformer.cc',
   'AlgorithmSequence.cc',

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -1,6 +1,4 @@
 #include "algorithms/AlgorithmSequence.h"
-#include "algorithms/clas12/event_builder_filter/EventBuilderFilter.h"
-#include "algorithms/clas12/lorentz_transformer/LorentzTransformer.h"
 #include <hipo4/reader.h>
 
 // show a bank along with a header
@@ -25,8 +23,8 @@ int main(int argc, char **argv) {
 
   // iguana algorithm sequence
   iguana::AlgorithmSequence seq;
-  seq.Add<iguana::clas12::EventBuilderFilter>("pid_filter"); // filter by Event Builder PID
-  seq.Add<iguana::clas12::LorentzTransformer>("new_frame");  // Lorentz transform the momenta
+  seq.Add("clas12::EventBuilderFilter", "pid_filter"); // filter by Event Builder PID
+  seq.Add("clas12::LorentzTransformer", "new_frame");  // Lorentz transform the momenta
   
   // set log levels
   seq.SetOption("pid_filter", "log", "debug");

--- a/src/tests/run_banks.cc
+++ b/src/tests/run_banks.cc
@@ -23,16 +23,16 @@ int main(int argc, char **argv) {
 
   // iguana algorithm sequence
   iguana::AlgorithmSequence seq;
-  seq.Add("clas12::EventBuilderFilter", "pid_filter"); // filter by Event Builder PID
-  seq.Add("clas12::LorentzTransformer", "new_frame");  // Lorentz transform the momenta
+  seq.Add("clas12::EventBuilderFilter"); // filter by Event Builder PID
+  seq.Add("clas12::LorentzTransformer"); // Lorentz transform the momenta
   
   // set log levels
-  seq.SetOption("pid_filter", "log", "debug");
-  seq.SetOption("new_frame",  "log", "debug");
+  seq.SetOption("clas12::EventBuilderFilter", "log", "debug");
+  seq.SetOption("clas12::LorentzTransformer", "log", "debug");
 
   // set algorithm options
-  seq.SetOption("pid_filter", "pids",  std::set<int>{11, 211, -211});
-  seq.SetOption("new_frame",  "frame", "mirror");
+  seq.SetOption("clas12::EventBuilderFilter", "pids",  std::set<int>{11, 211, -211});
+  seq.SetOption("clas12::LorentzTransformer", "frame", "mirror");
 
   // start the algorithms
   seq.Start(banks);


### PR DESCRIPTION
### Problem
To mitigate language bindings, it would be useful to be able to create algorithms by only knowing their `string` names. Since C++ doesn't have reflection, we need some other approach.

### Solution
Use a factory to create an algorithm on-the-fly. Algorithms only need to self-register with a unique name, which is hard-coded as their class name.

This was done following https://www.cppstories.com/2018/02/factory-selfregister/

- **BEWARE** of a pitfall where `static unordered_map AlgorithmFactory::s_creators` may not exist before it is filled; I think if the linking order is _always_ correct, this shouldn't bite us.
  - Details: https://stackoverflow.com/questions/48578226/c-static-initialization-order-adding-into-a-map
  - C++20 `constinit` may save us: https://www.cppstories.com/2023/ub-factory-constinit/