### PR TITLE
build: use `pkg-config` for `hipo4`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 env:
-  hipo_version: 380d54ec47086b31fe13e637329748b2df06ea84
+  hipo_version: dev
   fmt_version: 9.1.0
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
       - name: checkout hipo
         uses: actions/checkout@v4
         with:
-          repository: gavalian/hipo
+          repository: c-dilks/hipo # FIXME: revert to gavalian
           ref: ${{ env.hipo_version }}
       - name: build
         run: |
@@ -241,13 +241,9 @@ jobs:
         run: |
           ls *.tar.gz | xargs -I{} tar xzvf {}
           rm -v *.tar.gz
-      - name: set HIPO env vars
-        run: |
-          hipodir=$(pwd)/hipo
-          echo CMAKE_PREFIX_PATH=${hipodir} >> $GITHUB_ENV
-          if [ "${{ matrix.tool }}" = "make" ]; then
-            echo HIPO=${hipodir} >> $GITHUB_ENV
-          fi
+      - name: set cmake prefix path
+        if: ${{ matrix.tool == 'cmake' }}
+        run: echo CMAKE_PREFIX_PATH=$(pwd)/hipo >> $GITHUB_ENV
       - name: build and run
         run: |
           source iguana/bin/this_iguana.sh

--- a/bind/python/pyiguana/__init__.py
+++ b/bind/python/pyiguana/__init__.py
@@ -2,17 +2,11 @@
 
 import os, cppyy, pkgconfig
 
-# read iguana pkg-config
-PKG = 'iguana'
-if not pkgconfig.exists(PKG):
-    raise Exception(f'failed to find pkg-config package "{PKG}"')
-pkg_vars = pkgconfig.variables(PKG)
-
-# add include dirs to cppyy
-for var in ['includedir', 'dep_includedirs']:
-    include_path = pkg_vars[var]
-    for path in include_path.split(':'):
-        cppyy.add_include_path(path)
+# add include directories to cppyy
+for pkg in ['hipo4', 'iguana']:
+    if not pkgconfig.exists(pkg):
+        raise Exception(f'failed to find "{pkg}.pc" in pkg-config path')
+    cppyy.add_include_path(pkgconfig.variables(pkg)['includedir'])
 
 # add libraries to cppyy
 for lib in ['hipo4', 'IguanaServices', 'IguanaAlgorithms']:

--- a/bind/python/pyiguana/__init__.py
+++ b/bind/python/pyiguana/__init__.py
@@ -2,11 +2,12 @@
 
 import os, cppyy, pkgconfig
 
-# add include directories to cppyy
+# add include and library directories to cppyy
 for pkg in ['iguana'] + [p.split()[0] for p in pkgconfig.requires('iguana') if p!='']:
     if not pkgconfig.exists(pkg):
         raise Exception(f'failed to find "{pkg}.pc" in pkg-config path')
     cppyy.add_include_path(pkgconfig.variables(pkg)['includedir'])
+    cppyy.add_library_path(pkgconfig.variables(pkg)['libdir'])
 
 # add libraries to cppyy
 for lib in ['hipo4', 'IguanaServices', 'IguanaAlgorithms']:

--- a/bind/python/pyiguana/__init__.py
+++ b/bind/python/pyiguana/__init__.py
@@ -11,7 +11,7 @@ for pkg in ['iguana'] + [p.split()[0] for p in pkgconfig.requires('iguana') if p
 
 # add libraries to cppyy
 for lib in ['hipo4', 'IguanaServices', 'IguanaAlgorithms']:
-  cppyy.load_library(lib)
+    cppyy.load_library(lib)
 
 # include header file(s)
 def include(*headers):

--- a/bind/python/pyiguana/__init__.py
+++ b/bind/python/pyiguana/__init__.py
@@ -3,7 +3,7 @@
 import os, cppyy, pkgconfig
 
 # add include directories to cppyy
-for pkg in ['hipo4', 'iguana']:
+for pkg in ['iguana'] + [p.split()[0] for p in pkgconfig.requires('iguana') if p!='']:
     if not pkgconfig.exists(pkg):
         raise Exception(f'failed to find "{pkg}.pc" in pkg-config path')
     cppyy.add_include_path(pkgconfig.variables(pkg)['includedir'])

--- a/configure.py
+++ b/configure.py
@@ -12,13 +12,13 @@ LIBDIR                = 'lib'
 # parse user options
 class Formatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter): pass
 parser = argparse.ArgumentParser(
-        usage = f'{sys.argv[0]} [OPTION]...',
-        description = textwrap.dedent('''
+    usage = f'{sys.argv[0]} [OPTION]...',
+    description = textwrap.dedent('''
         description:
           Generate a configuration file with build settings for iguana
         '''),
-        formatter_class = Formatter
-        )
+    formatter_class = Formatter
+)
 parser_deps = parser.add_argument_group('dependency installation paths')
 parser_deps.add_argument( '--hipo', default=SYSTEM_ASSUMPTION, type=str, help='path to `hipo` installation')
 parser_deps.add_argument( '--fmt', default=SYSTEM_ASSUMPTION, type=str, help='path to `fmt` installation')

--- a/configure.py
+++ b/configure.py
@@ -38,16 +38,16 @@ installDir = os.path.realpath(args.prefix)
 sourceDir  = os.path.dirname(os.path.realpath(__file__))
 
 # set dependency paths
-cmake_prefix_path = []
-cmake_deps        = []
-pkg_config_path   = []
-pkg_config_deps   = []
+cmake_prefix_path = set()
+cmake_deps        = set()
+pkg_config_path   = set()
+pkg_config_deps   = set()
 if(args.hipo != SYSTEM_ASSUMPTION):
-    cmake_prefix_path.append(os.path.realpath(args.hipo))
-    cmake_deps.append('hipo')
+    pkg_config_path.add(os.path.realpath(args.hipo) + '/lib/pkgconfig')
+    pkg_config_deps.add('hipo')
 if(args.fmt != SYSTEM_ASSUMPTION):
-    pkg_config_path.append(os.path.realpath(args.fmt) + '/lib/pkgconfig')
-    pkg_config_deps.append('fmt')
+    pkg_config_path.add(os.path.realpath(args.fmt) + '/lib/pkgconfig')
+    pkg_config_deps.add('fmt')
 
 # return an array of strings for meson's INI parsing
 def meson_string_array(arr):

--- a/examples/build_with_cmake/CMakeLists.txt
+++ b/examples/build_with_cmake/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 # find dependencies
 # - iguana doesn't create a `iguanaConfig.cmake` file, but it does create a pkg-config `.pc` file;
-#   the target will be imported as `PkgConfig::iguana`
+#   using `PkgConfig`, the iguana target will be imported as `PkgConfig::iguana`
 find_package(hipo4 REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(iguana REQUIRED IMPORTED_TARGET iguana)

--- a/examples/build_with_make/Makefile
+++ b/examples/build_with_make/Makefile
@@ -9,8 +9,9 @@ IGUANA_LIBRARIES := $(shell pkg-config --libs   iguana)
 # set rpath
 # - this is so that the executable knows where the dependency libraries are
 # - alternatively, set $LD_LIBRARY_PATH before running your executables
-get_libdir = -rpath=$(shell pkg-config --variable libdir $1)
-LDFLAGS := -Wl,$(call get_libdir, iguana),$(call get_libdir, hipo4)
+RPATH_DEPS := iguana hipo4
+rpath_arg = -Wl,-rpath,$(shell pkg-config --variable libdir $1)
+LDFLAGS := $(foreach dep,$(RPATH_DEPS),$(call rpath_arg,$(dep)))
 
 # installation directory
 BINDIR := bin

--- a/examples/build_with_make/Makefile
+++ b/examples/build_with_make/Makefile
@@ -1,22 +1,30 @@
 # compiler
 CXX := g++
-FLAGS := -std=c++17
+CFLAGS := -std=c++17
 
-# dependency libraries
-DEP_LIBRARIES = $(shell pkg-config --libs iguana)
+# iguana headers and libraries
+IGUANA_INCLUDES  := $(shell pkg-config --cflags iguana)
+IGUANA_LIBRARIES := $(shell pkg-config --libs   iguana)
 
-# dependency headers
-DEP_INCLUDES = $(shell pkg-config --cflags iguana)
+# set rpath
+# - this is so that the executable knows where the dependency libraries are
+# - alternatively, set $LD_LIBRARY_PATH before running your executables
+get_libdir = -rpath=$(shell pkg-config --variable libdir $1)
+LDFLAGS := -Wl,$(call get_libdir, iguana),$(call get_libdir, hipo4)
 
-# assume each .cc file has `main`; install it to ./bin/
-BINDIR = bin
+# installation directory
+BINDIR := bin
+
+# assume we want each `.cc` file built as an executable
 EXECUTABLES := $(addprefix $(BINDIR)/, $(basename $(wildcard *.cc)))
 
-# build executable
-# - NOTE: we haven't set an rpath here, so the user will need
-#   to make sure dependency libraries are found in $LD_LIBRARY_PATH
+# build each executable and install to $(BINDIR)
 $(EXECUTABLES): $(BINDIR)/%: %.cc
 	mkdir -p $(BINDIR)
-	$(CXX) -c $< -o $@.o $(FLAGS) $(DEP_INCLUDES)
-	$(CXX) -o $@ $@.o $(DEP_LIBRARIES)
+	$(CXX) -c $< -o $@.o $(CFLAGS) $(IGUANA_INCLUDES)
+	$(CXX) -o $@ $@.o $(LDFLAGS) $(IGUANA_LIBRARIES)
 	$(RM) $@.o
+
+# remove the executable
+clean:
+	$(RM) $(EXECUTABLES)

--- a/examples/build_with_make/Makefile
+++ b/examples/build_with_make/Makefile
@@ -4,11 +4,9 @@ FLAGS := -std=c++17
 
 # dependency libraries
 DEP_LIBRARIES = $(shell pkg-config --libs iguana)
-DEP_LIBRARIES += -L${HIPO}/lib -lhipo4
 
 # dependency headers
 DEP_INCLUDES = $(shell pkg-config --cflags iguana)
-DEP_INCLUDES += -I${HIPO}/include
 
 # assume each .cc file has `main`; install it to ./bin/
 BINDIR = bin

--- a/examples/build_with_make/README.md
+++ b/examples/build_with_make/README.md
@@ -12,4 +12,3 @@ pkg-config --libs iguana
 pkg-config --cflags iguana
 ```
 - These commands are used in the example `Makefile`
-- `hipo` is assumed to be installed in `$HIPO`.

--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -7,7 +7,6 @@ project(
 
 # find dependencies
 # - it's good practice to specifiy minimum version requirements; here we just assume that `iguana` already did this
-hipo_dep   = dependency('hipo4')
 iguana_dep = dependency('iguana')
 
 # set rpath
@@ -26,7 +25,7 @@ example_bin = 'iguana-example-00-basic'
 executable(
   example_bin,
   example_bin + '.cc',
-  dependencies:  [ hipo_dep, iguana_dep ],
+  dependencies:  [ iguana_dep ],
   install:       true,
   install_rpath: ':'.join(bin_rpaths),
 )

--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -7,17 +7,17 @@ project(
 
 # find dependencies
 # - it's good practice to specifiy minimum version requirements; here we just assume that `iguana` already did this
-iguana_dep = dependency('iguana')
+bin_deps = [
+  dependency('hipo4'),
+  dependency('iguana'),
+]
 
 # set rpath
 # - this is so that the executable knows where the dependency libraries are
 # - alternatively, set $LD_LIBRARY_PATH before running your executables
 bin_rpaths = []
-foreach path : get_option('cmake_prefix_path')
-  bin_rpaths += path / 'lib'
-endforeach
-foreach path : get_option('pkg_config_path')
-  bin_rpaths += path / '..'
+foreach dep : bin_deps
+  bin_rpaths += dep.get_variable('libdir')
 endforeach
 
 # build and install the executable
@@ -25,7 +25,7 @@ example_bin = 'iguana-example-00-basic'
 executable(
   example_bin,
   example_bin + '.cc',
-  dependencies:  [ iguana_dep ],
+  dependencies:  bin_deps,
   install:       true,
   install_rpath: ':'.join(bin_rpaths),
 )

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -4,7 +4,10 @@ example_sources = [
 ]
 
 # add iguana libraries to rpath
-example_rpaths = [ '$ORIGIN' / '..' / get_option('libdir') ] + dep_lib_paths
+example_rpaths = [
+  '$ORIGIN' / '..' / get_option('libdir'),
+  hipo_dep.get_variable(pkgconfig: 'libdir'),
+]
 
 # build executables
 foreach src : example_sources

--- a/meson.build
+++ b/meson.build
@@ -13,42 +13,16 @@ project(
 project_description = 'Implementation Guardian of Analysis Algorithms'
 
 # resolve dependencies
-fmt_dep  = dependency('fmt', version: '>=9.1.0')
-hipo_dep = dependency('hipo4', version: '>=1.3', method: 'cmake')
-
-# dependency paths for pkg-config packaging
-dep_lib_paths        = []
-dep_include_paths    = []
-dep_pkg_config_paths = []
-# cmake dependency libraries and headers
-# FIXME: prefer `dep.get_variable(cmake: 'VARIABLE_NAME')`, but not sure if the needed variables are available...
-#        - if HIPO had a pkg-config file, we could:
-#          - get rid of this `cmake_prefix_path` loop and move `hipo_dep` into the `get_variable` loop
-#          - replace `$HIPO` in the Makefile example with a pkg-config command
-#          - remove `$HIPO` assignment in the Makefile CI job description
-foreach path : get_option('cmake_prefix_path')
-  dep_lib_paths     += path / 'lib'
-  dep_include_paths += path / 'include'
-endforeach
-# pkg-config dependency libraries and headers
-foreach dep : [fmt_dep]
-  dep_lib_paths     += dep.get_variable(pkgconfig: 'libdir')
-  dep_include_paths += dep.get_variable(pkgconfig: 'includedir')
-endforeach
-# dependency pkg-config paths
-foreach path : get_option('pkg_config_path')
-  dep_pkg_config_paths += path
-endforeach
+fmt_dep  = dependency('fmt',   version: '>=9.1.0', method: 'pkg-config')
+hipo_dep = dependency('hipo4', version: '>=4.0.1', method: 'pkg-config')
 
 # general project vars
 project_lib_rpath = '$ORIGIN'
 project_inc       = include_directories('src')
 project_libs      = []
 project_deps      = declare_dependency(dependencies: [ fmt_dep, hipo_dep ])
-project_pkg_vars = [
-  'dep_libdirs='       + ':'.join(dep_lib_paths),
-  'dep_includedirs='   + ':'.join(dep_include_paths),
-  'dep_pkgconfigdirs=' + ':'.join(dep_pkg_config_paths),
+project_pkg_vars  = [
+  'dep_pkgconfigdirs=' + ':'.join(get_option('pkg_config_path'))
 ]
 
 # build and install shared libraries
@@ -56,7 +30,7 @@ subdir('src/iguana/services')
 subdir('src/iguana/algorithms')
 
 # build bindings
-if(get_option('bind_python'))
+if get_option('bind_python')
   subdir('bind/python')
 endif
 
@@ -66,19 +40,19 @@ pkg.generate(
   name:        meson.project_name(),
   description: project_description,
   libraries:   project_libs,
-  requires:    [ fmt_dep ],
+  requires:    [ fmt_dep, hipo_dep ],
   variables:   project_pkg_vars,
 )
 
 # build examples
-if(get_option('examples'))
+if get_option('examples')
   subdir('examples')
 endif
 
 # generate documentation
-if(get_option('documentation'))
+if get_option('documentation')
   doxygen = find_program('doxygen', required: false)
-  if(doxygen.found())
+  if doxygen.found()
     message('Generating documentation...')
     run_command('doxygen', meson.project_source_root() / 'doc' / 'Doxyfile', check: true)
     message('...documentation generated.')

--- a/meson/this_iguana.sh.in
+++ b/meson/this_iguana.sh.in
@@ -27,8 +27,8 @@ iguana_pythonpath=$(pkg-config --variable pythonpath iguana)
 echo """
 Iguana Environment Variables
 ----------------------------
-PKG_CONFIG_PATH     = ${PKG_CONFIG_PATH-}
-LD_LIBRARY_PATH     = ${LD_LIBRARY_PATH-}
-PYTHONPATH          = ${PYTHONPATH-}
+PKG_CONFIG_PATH = ${PKG_CONFIG_PATH-}
+LD_LIBRARY_PATH = ${LD_LIBRARY_PATH-}
+PYTHONPATH      = ${PYTHONPATH-}
 ----------------------------
 """

--- a/meson/this_iguana.sh.in
+++ b/meson/this_iguana.sh.in
@@ -10,16 +10,6 @@ export PKG_CONFIG_PATH=$thisDir/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PA
 dep_pkgconfigdirs=$(pkg-config --variable dep_pkgconfigdirs iguana)
 [ -n "${dep_pkgconfigdirs-}" ] && export PKG_CONFIG_PATH=$dep_pkgconfigdirs${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
 
-# append to LD_LIBRARY_PATH
-deps=(
-  iguana
-  $(pkg-config --print-requires iguana | awk '{print $1}')
-)
-for dep in ${deps[*]}; do
-  dir=$(pkg-config --variable libdir $dep)
-  [ -n "${dir-}" ] && export LD_LIBRARY_PATH=$dir${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-done
-
 # append to PYTHONPATH
 iguana_pythonpath=$(pkg-config --variable pythonpath iguana)
 [ -n "${iguana_pythonpath-}" ] && export PYTHONPATH=$iguana_pythonpath${PYTHONPATH:+:${PYTHONPATH}}
@@ -28,7 +18,6 @@ echo """
 Iguana Environment Variables
 ----------------------------
 PKG_CONFIG_PATH = ${PKG_CONFIG_PATH-}
-LD_LIBRARY_PATH = ${LD_LIBRARY_PATH-}
 PYTHONPATH      = ${PYTHONPATH-}
 ----------------------------
 """

--- a/meson/this_iguana.sh.in
+++ b/meson/this_iguana.sh.in
@@ -11,8 +11,12 @@ dep_pkgconfigdirs=$(pkg-config --variable dep_pkgconfigdirs iguana)
 [ -n "${dep_pkgconfigdirs-}" ] && export PKG_CONFIG_PATH=$dep_pkgconfigdirs${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
 
 # append to LD_LIBRARY_PATH
-for var in libdir dep_libdirs; do
-  dir=$(pkg-config --variable $var iguana)
+deps=(
+  iguana
+  $(pkg-config --print-requires iguana | awk '{print $1}')
+)
+for dep in ${deps[*]}; do
+  dir=$(pkg-config --variable libdir $dep)
   [ -n "${dir-}" ] && export LD_LIBRARY_PATH=$dir${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 done
 


### PR DESCRIPTION
Build configuration is much easier when upstream uses `pkg-config`.

Requires https://github.com/gavalian/hipo/pull/42