### PR TITLE
feat: generate algorithm boilerplate with preprocessor macros

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -983,56 +983,7 @@ INPUT_FILE_ENCODING    =
 # provided as doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
 
-FILE_PATTERNS          = *.c \
-                         *.cc \
-                         *.cxx \
-                         *.cxxm \
-                         *.cpp \
-                         *.cppm \
-                         *.c++ \
-                         *.c++m \
-                         *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.idl \
-                         *.ddl \
-                         *.odl \
-                         *.h \
-                         *.hh \
-                         *.hxx \
-                         *.hpp \
-                         *.h++ \
-                         *.ixx \
-                         *.l \
-                         *.cs \
-                         *.d \
-                         *.php \
-                         *.php4 \
-                         *.php5 \
-                         *.phtml \
-                         *.inc \
-                         *.m \
-                         *.markdown \
-                         *.md \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.pyw \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f18 \
-                         *.f \
-                         *.for \
-                         *.vhd \
-                         *.vhdl \
-                         *.ucf \
-                         *.qsf \
-                         *.ice
+FILE_PATTERNS          = *.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -10,6 +10,7 @@
 #include <hipo4/bank.h>
 
 #include "iguana/services/Object.h"
+#include "iguana/algorithms/AlgorithmBoilerplate.h"
 
 namespace iguana {
 

--- a/src/iguana/algorithms/AlgorithmBoilerplate.h
+++ b/src/iguana/algorithms/AlgorithmBoilerplate.h
@@ -3,18 +3,18 @@
 
 /// Generate an algorithm constructor
 /// @param ALGO_NAME the name of the algorithm class
-#define CONSTRUCT_ALGORITHM(ALGO_NAME) \
+#define CONSTRUCT_IGUANA_ALGORITHM(ALGO_NAME) \
   ALGO_NAME(std::string name="") : Algorithm(name=="" ? ClassName() : name) {}
 
 /// Generate an algorithm destructor
 /// @param ALGO_NAME the name of the algorithm class
-#define DESTROY_ALGORITHM(ALGO_NAME) \
+#define DESTROY_IGUANA_ALGORITHM(ALGO_NAME) \
   ~ALGO_NAME() {}
 
 /// Define the public members of an algorithm
 /// @param ALGO_NAME the name of the algorithm class
 /// @param ALGO_FULL_NAME the full name of this algorithm, used by `iguana::AlgorithmFactory`
-#define ALGORITHM_PUBLIC_MEMBERS(ALGO_NAME, ALGO_FULL_NAME)         \
+#define IGUANA_ALGORITHM_PUBLIC_MEMBERS(ALGO_NAME, ALGO_FULL_NAME)  \
   using Algorithm::Start;                                           \
   void Start(hipo::banklist& banks) override;                       \
   void Run(hipo::banklist& banks) const override;                   \
@@ -23,37 +23,37 @@
   static std::string ClassName() { return #ALGO_FULL_NAME; }
 
 /// Define the private members of an algorithm
-#define ALGORITHM_PRIVATE_MEMBERS \
+#define IGUANA_ALGORITHM_PRIVATE_MEMBERS \
   static bool s_registered;
 
 /// Define the public and private members of an algorithm, along with its constructor and destructor; this
 /// macro should be called in the `class` body in the algorithm's header file
 /// @param ALGO_NAME the name of the algorithm class
 /// @param ALGO_FULL_NAME the full name of this algorithm, used by `iguana::AlgorithmFactory`
-#define DEFINE_ALGORITHM(ALGO_NAME, ALGO_FULL_NAME) \
-  private:                                          \
-    ALGORITHM_PRIVATE_MEMBERS                       \
-  public:                                           \
-    CONSTRUCT_ALGORITHM(ALGO_NAME)                  \
-    DESTROY_ALGORITHM(ALGO_NAME)                    \
-    ALGORITHM_PUBLIC_MEMBERS(ALGO_NAME, ALGO_FULL_NAME)
+#define DEFINE_IGUANA_ALGORITHM(ALGO_NAME, ALGO_FULL_NAME) \
+  private:                                                 \
+    IGUANA_ALGORITHM_PRIVATE_MEMBERS                       \
+  public:                                                  \
+    CONSTRUCT_IGUANA_ALGORITHM(ALGO_NAME)                  \
+    DESTROY_IGUANA_ALGORITHM(ALGO_NAME)                    \
+    IGUANA_ALGORITHM_PUBLIC_MEMBERS(ALGO_NAME, ALGO_FULL_NAME)
 
 /// Register an algorithm for the `iguana::AlgorithmFactory`; this macro should be called in the algorithm's implementation
 /// @param ALGO_NAME the name of the algorithm class
-#define REGISTER_ALGORITHM(ALGO_NAME) \
+#define REGISTER_IGUANA_ALGORITHM(ALGO_NAME) \
   bool ALGO_NAME::s_registered = AlgorithmFactory::Register(ALGO_NAME::ClassName(), ALGO_NAME::Creator);
 
 /// Define the algorithm's `Start` method
 /// @param ALGO_NAME the name of the algorithm class
-#define START_ALGORITHM(ALGO_NAME) \
+#define START_IGUANA_ALGORITHM(ALGO_NAME) \
   void ALGO_NAME::Start(hipo::banklist& banks)
 
 /// Define the algorithm's `Run` method
 /// @param ALGO_NAME the name of the algorithm class
-#define RUN_ALGORITHM(ALGO_NAME) \
+#define RUN_IGUANA_ALGORITHM(ALGO_NAME) \
   void ALGO_NAME::Run(hipo::banklist& banks) const
 
 /// Define the algorithm's `Stop` method
 /// @param ALGO_NAME the name of the algorithm class
-#define STOP_ALGORITHM(ALGO_NAME) \
+#define STOP_IGUANA_ALGORITHM(ALGO_NAME) \
   void ALGO_NAME::Stop()

--- a/src/iguana/algorithms/AlgorithmBoilerplate.h
+++ b/src/iguana/algorithms/AlgorithmBoilerplate.h
@@ -1,0 +1,59 @@
+/// @file AlgorithmBoilerplate.h
+/// @brief Preprocessor macros to generate standardized algorithm boilerplate code
+
+/// Generate an algorithm constructor
+/// @param ALGO_NAME the name of the algorithm class
+#define CONSTRUCT_ALGORITHM(ALGO_NAME) \
+  ALGO_NAME(std::string name="") : Algorithm(name=="" ? ClassName() : name) {}
+
+/// Generate an algorithm destructor
+/// @param ALGO_NAME the name of the algorithm class
+#define DESTROY_ALGORITHM(ALGO_NAME) \
+  ~ALGO_NAME() {}
+
+/// Define the public members of an algorithm
+/// @param ALGO_NAME the name of the algorithm class
+/// @param ALGO_FULL_NAME the full name of this algorithm, used by `iguana::AlgorithmFactory`
+#define ALGORITHM_PUBLIC_MEMBERS(ALGO_NAME, ALGO_FULL_NAME)         \
+  using Algorithm::Start;                                           \
+  void Start(hipo::banklist& banks) override;                       \
+  void Run(hipo::banklist& banks) const override;                   \
+  void Stop() override;                                             \
+  static algo_t Creator() { return std::make_unique<ALGO_NAME>(); } \
+  static std::string ClassName() { return #ALGO_FULL_NAME; }
+
+/// Define the private members of an algorithm
+#define ALGORITHM_PRIVATE_MEMBERS \
+  static bool s_registered;
+
+/// Define the public and private members of an algorithm, along with its constructor and destructor; this
+/// macro should be called in the `class` body in the algorithm's header file
+/// @param ALGO_NAME the name of the algorithm class
+/// @param ALGO_FULL_NAME the full name of this algorithm, used by `iguana::AlgorithmFactory`
+#define DEFINE_ALGORITHM(ALGO_NAME, ALGO_FULL_NAME) \
+  private:                                          \
+    ALGORITHM_PRIVATE_MEMBERS                       \
+  public:                                           \
+    CONSTRUCT_ALGORITHM(ALGO_NAME)                  \
+    DESTROY_ALGORITHM(ALGO_NAME)                    \
+    ALGORITHM_PUBLIC_MEMBERS(ALGO_NAME, ALGO_FULL_NAME)
+
+/// Register an algorithm for the `iguana::AlgorithmFactory`; this macro should be called in the algorithm's implementation
+/// @param ALGO_NAME the name of the algorithm class
+#define REGISTER_ALGORITHM(ALGO_NAME) \
+  bool ALGO_NAME::s_registered = AlgorithmFactory::Register(ALGO_NAME::ClassName(), ALGO_NAME::Creator);
+
+/// Define the algorithm's `Start` method
+/// @param ALGO_NAME the name of the algorithm class
+#define START_ALGORITHM(ALGO_NAME) \
+  void ALGO_NAME::Start(hipo::banklist& banks)
+
+/// Define the algorithm's `Run` method
+/// @param ALGO_NAME the name of the algorithm class
+#define RUN_ALGORITHM(ALGO_NAME) \
+  void ALGO_NAME::Run(hipo::banklist& banks) const
+
+/// Define the algorithm's `Stop` method
+/// @param ALGO_NAME the name of the algorithm class
+#define STOP_ALGORITHM(ALGO_NAME) \
+  void ALGO_NAME::Stop()

--- a/src/iguana/algorithms/AlgorithmSequence.cc
+++ b/src/iguana/algorithms/AlgorithmSequence.cc
@@ -2,6 +2,12 @@
 
 namespace iguana {
 
+  REGISTER_ALGORITHM(AlgorithmSequence);
+
+  START_ALGORITHM(AlgorithmSequence) { for(const auto& algo : m_sequence) algo->Start(banks); }
+  RUN_ALGORITHM(AlgorithmSequence)   { for(const auto& algo : m_sequence) algo->Run(banks);   }
+  STOP_ALGORITHM(AlgorithmSequence)  { for(const auto& algo : m_sequence) algo->Stop();       }
+
   void AlgorithmSequence::Add(const std::string class_name, const std::string instance_name) {
     auto algo = AlgorithmFactory::Create(class_name);
     if(algo==nullptr) {
@@ -40,21 +46,6 @@ namespace iguana {
     m_log->Print(level, "algorithms in this sequence:");
     for(const auto& algo : m_sequence)
       m_log->Print(level, " - {}", algo->GetName());
-  }
-
-  void AlgorithmSequence::Start(hipo::banklist& banks) {
-    for(const auto& algo : m_sequence)
-      algo->Start(banks);
-  }
-
-  void AlgorithmSequence::Run(hipo::banklist& banks) const {
-    for(const auto& algo : m_sequence)
-      algo->Run(banks);
-  }
-
-  void AlgorithmSequence::Stop() {
-    for(const auto& algo : m_sequence)
-      algo->Stop();
   }
 
 }

--- a/src/iguana/algorithms/AlgorithmSequence.cc
+++ b/src/iguana/algorithms/AlgorithmSequence.cc
@@ -2,11 +2,11 @@
 
 namespace iguana {
 
-  REGISTER_ALGORITHM(AlgorithmSequence);
+  REGISTER_IGUANA_ALGORITHM(AlgorithmSequence);
 
-  START_ALGORITHM(AlgorithmSequence) { for(const auto& algo : m_sequence) algo->Start(banks); }
-  RUN_ALGORITHM(AlgorithmSequence)   { for(const auto& algo : m_sequence) algo->Run(banks);   }
-  STOP_ALGORITHM(AlgorithmSequence)  { for(const auto& algo : m_sequence) algo->Stop();       }
+  START_IGUANA_ALGORITHM(AlgorithmSequence) { for(const auto& algo : m_sequence) algo->Start(banks); }
+  RUN_IGUANA_ALGORITHM(AlgorithmSequence)   { for(const auto& algo : m_sequence) algo->Run(banks);   }
+  STOP_IGUANA_ALGORITHM(AlgorithmSequence)  { for(const auto& algo : m_sequence) algo->Stop();       }
 
   void AlgorithmSequence::Add(const std::string class_name, const std::string instance_name) {
     auto algo = AlgorithmFactory::Create(class_name);

--- a/src/iguana/algorithms/AlgorithmSequence.h
+++ b/src/iguana/algorithms/AlgorithmSequence.h
@@ -10,7 +10,7 @@ namespace iguana {
   /// in the order the algorithms were added to the sequence by `AlgorithmSequence::Add`.
   class AlgorithmSequence : public Algorithm {
 
-    DEFINE_ALGORITHM(AlgorithmSequence, seq)
+    DEFINE_IGUANA_ALGORITHM(AlgorithmSequence, seq)
 
     public:
 

--- a/src/iguana/algorithms/AlgorithmSequence.h
+++ b/src/iguana/algorithms/AlgorithmSequence.h
@@ -5,13 +5,14 @@
 namespace iguana {
 
   /// @brief User-level class for running a sequence of algorithms
+  ///
+  /// The `Start`, `Run`, and `Stop` methods will sequentially call the corresponding algorithms' methods,
+  /// in the order the algorithms were added to the sequence by `AlgorithmSequence::Add`.
   class AlgorithmSequence : public Algorithm {
 
-    public:
+    DEFINE_ALGORITHM(AlgorithmSequence, seq)
 
-      /// @param name the name of this sequence
-      AlgorithmSequence(const std::string name="seq") : Algorithm(name) {}
-      ~AlgorithmSequence() {}
+    public:
 
       /// Create and add an algorithm to the sequence, by name.
       ///
@@ -83,20 +84,6 @@ namespace iguana {
       /// Print the names of the algorithms in this sequence
       /// @param level the log level of the printout
       void PrintSequence(Logger::Level level=Logger::info) const;
-
-      /// Sequentially call each algorithm's `Start` method
-      /// @see `Algorithm::Start`
-      /// @param banks the list of banks
-      void Start(hipo::banklist& banks) override;
-
-      /// Sequentially call each algorithm's `Run` method
-      /// @see `Algorithm::Run`
-      /// @param banks the list of banks
-      void Run(hipo::banklist& banks) const override;
-
-      /// Sequentially call each algorithm's `Stop` method
-      /// @see `Algorithm::Stop`
-      void Stop() override;
 
     private:
 

--- a/src/iguana/algorithms/clas12/EventBuilderFilter.cc
+++ b/src/iguana/algorithms/clas12/EventBuilderFilter.cc
@@ -2,9 +2,9 @@
 
 namespace iguana::clas12 {
 
-  REGISTER_ALGORITHM(EventBuilderFilter);
+  REGISTER_IGUANA_ALGORITHM(EventBuilderFilter);
 
-  START_ALGORITHM(EventBuilderFilter) {
+  START_IGUANA_ALGORITHM(EventBuilderFilter) {
 
     // define options, their default values, and cache them
     CacheOptionToSet("pids", {11, 211}, o_pids);
@@ -18,7 +18,7 @@ namespace iguana::clas12 {
   }
 
 
-  RUN_ALGORITHM(EventBuilderFilter) {
+  RUN_IGUANA_ALGORITHM(EventBuilderFilter) {
 
     // get the banks
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
@@ -46,7 +46,7 @@ namespace iguana::clas12 {
   }
 
 
-  STOP_ALGORITHM(EventBuilderFilter) {
+  STOP_IGUANA_ALGORITHM(EventBuilderFilter) {
     m_log->Info("test info");
     m_log->Warn("test warn");
     m_log->Error("test error");

--- a/src/iguana/algorithms/clas12/EventBuilderFilter.cc
+++ b/src/iguana/algorithms/clas12/EventBuilderFilter.cc
@@ -2,13 +2,9 @@
 
 namespace iguana::clas12 {
 
-  bool EventBuilderFilter::s_registered = AlgorithmFactory::Register(
-      EventBuilderFilter::ClassName(),
-      EventBuilderFilter::Creator
-      );
+  REGISTER_ALGORITHM(EventBuilderFilter);
 
-
-  void EventBuilderFilter::Start(hipo::banklist& banks) {
+  START_ALGORITHM(EventBuilderFilter) {
 
     // define options, their default values, and cache them
     CacheOptionToSet("pids", {11, 211}, o_pids);
@@ -22,7 +18,7 @@ namespace iguana::clas12 {
   }
 
 
-  void EventBuilderFilter::Run(hipo::banklist& banks) const {
+  RUN_ALGORITHM(EventBuilderFilter) {
 
     // get the banks
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
@@ -50,7 +46,7 @@ namespace iguana::clas12 {
   }
 
 
-  void EventBuilderFilter::Stop() {
+  STOP_ALGORITHM(EventBuilderFilter) {
     m_log->Info("test info");
     m_log->Warn("test warn");
     m_log->Error("test error");

--- a/src/iguana/algorithms/clas12/EventBuilderFilter.h
+++ b/src/iguana/algorithms/clas12/EventBuilderFilter.h
@@ -7,20 +7,9 @@ namespace iguana::clas12 {
   /// @brief Filter the `REC::Particle` (or similar) bank by PID from the Event Builder
   class EventBuilderFilter : public Algorithm {
 
+    DEFINE_ALGORITHM(EventBuilderFilter, clas12::EventBuilderFilter)
+
     public:
-
-      /// @see `Algorithm::Algorithm`
-      EventBuilderFilter(std::string name="") : Algorithm(name=="" ? ClassName() : name) {}
-      ~EventBuilderFilter() {}
-      /// @returns An instance of this algorithm. This is used by `AlgorithmFactory`.
-      static algo_t Creator() { return std::make_unique<EventBuilderFilter>(); }
-      /// @returns This algorithm's class name
-      static std::string ClassName() { return "clas12::EventBuilderFilter"; }
-
-      using Algorithm::Start;
-      void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks) const override;
-      void Stop() override;
 
       /// **Action function**: checks if the PDG `pid` is a part of the list of user-specified PDGs
       /// @param pid the particle PDG to check
@@ -28,9 +17,6 @@ namespace iguana::clas12 {
       bool Filter(const int pid) const;
 
     private:
-
-      /// True if this algorithm is registered in `AlgorithmFactory`
-      static bool s_registered;
 
       /// `hipo::banklist` index for the particle bank
       hipo::banklist::size_type b_particle, b_calo; // TODO: remove calorimeter

--- a/src/iguana/algorithms/clas12/EventBuilderFilter.h
+++ b/src/iguana/algorithms/clas12/EventBuilderFilter.h
@@ -7,7 +7,7 @@ namespace iguana::clas12 {
   /// @brief Filter the `REC::Particle` (or similar) bank by PID from the Event Builder
   class EventBuilderFilter : public Algorithm {
 
-    DEFINE_ALGORITHM(EventBuilderFilter, clas12::EventBuilderFilter)
+    DEFINE_IGUANA_ALGORITHM(EventBuilderFilter, clas12::EventBuilderFilter)
 
     public:
 

--- a/src/iguana/algorithms/clas12/LorentzTransformer.cc
+++ b/src/iguana/algorithms/clas12/LorentzTransformer.cc
@@ -2,13 +2,9 @@
 
 namespace iguana::clas12 {
 
-  bool LorentzTransformer::s_registered = AlgorithmFactory::Register(
-      LorentzTransformer::ClassName(),
-      LorentzTransformer::Creator
-      );
+  REGISTER_ALGORITHM(LorentzTransformer);
 
-
-  void LorentzTransformer::Start(hipo::banklist& banks) {
+  START_ALGORITHM(LorentzTransformer) {
 
     CacheOption("frame", std::string{"mirror"}, o_frame);
     CacheBankIndex(banks, "REC::Particle", b_particle);
@@ -29,7 +25,7 @@ namespace iguana::clas12 {
   }
 
 
-  void LorentzTransformer::Run(hipo::banklist& banks) const {
+  RUN_ALGORITHM(LorentzTransformer) {
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
     ShowBank(particleBank, Logger::Header("INPUT PARTICLES"));
     for(int row = 0; row < particleBank.getRows(); row++) {
@@ -58,7 +54,7 @@ namespace iguana::clas12 {
   }
 
 
-  void LorentzTransformer::Stop() {
+  STOP_ALGORITHM(LorentzTransformer) {
   }
 
 }

--- a/src/iguana/algorithms/clas12/LorentzTransformer.cc
+++ b/src/iguana/algorithms/clas12/LorentzTransformer.cc
@@ -2,9 +2,9 @@
 
 namespace iguana::clas12 {
 
-  REGISTER_ALGORITHM(LorentzTransformer);
+  REGISTER_IGUANA_ALGORITHM(LorentzTransformer);
 
-  START_ALGORITHM(LorentzTransformer) {
+  START_IGUANA_ALGORITHM(LorentzTransformer) {
 
     CacheOption("frame", std::string{"mirror"}, o_frame);
     CacheBankIndex(banks, "REC::Particle", b_particle);
@@ -25,7 +25,7 @@ namespace iguana::clas12 {
   }
 
 
-  RUN_ALGORITHM(LorentzTransformer) {
+  RUN_IGUANA_ALGORITHM(LorentzTransformer) {
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
     ShowBank(particleBank, Logger::Header("INPUT PARTICLES"));
     for(int row = 0; row < particleBank.getRows(); row++) {
@@ -54,7 +54,7 @@ namespace iguana::clas12 {
   }
 
 
-  STOP_ALGORITHM(LorentzTransformer) {
+  STOP_IGUANA_ALGORITHM(LorentzTransformer) {
   }
 
 }

--- a/src/iguana/algorithms/clas12/LorentzTransformer.h
+++ b/src/iguana/algorithms/clas12/LorentzTransformer.h
@@ -11,7 +11,7 @@ namespace iguana::clas12 {
   /// - `"mirror"`: reverse the momentum (just a demo)
   class LorentzTransformer : public Algorithm {
 
-    DEFINE_ALGORITHM(LorentzTransformer, clas12::LorentzTransformer)
+    DEFINE_IGUANA_ALGORITHM(LorentzTransformer, clas12::LorentzTransformer)
 
     public:
 

--- a/src/iguana/algorithms/clas12/LorentzTransformer.h
+++ b/src/iguana/algorithms/clas12/LorentzTransformer.h
@@ -11,6 +11,8 @@ namespace iguana::clas12 {
   /// - `"mirror"`: reverse the momentum (just a demo)
   class LorentzTransformer : public Algorithm {
 
+    DEFINE_ALGORITHM(LorentzTransformer, clas12::LorentzTransformer)
+
     public:
 
       /// Lorentz vector element type, matching that of `REC::Particle` momentum components
@@ -18,19 +20,6 @@ namespace iguana::clas12 {
 
       /// Generic Lorentz vector container type
       using lorentz_vector_t = std::tuple<lorentz_element_t, lorentz_element_t, lorentz_element_t, lorentz_element_t>;
-
-      /// @see `Algorithm::Algorithm`
-      LorentzTransformer(std::string name="") : Algorithm(name=="" ? ClassName() : name) {}
-      ~LorentzTransformer() {}
-      /// @returns An instance of this algorithm. This is used by `AlgorithmFactory`.
-      static algo_t Creator() { return std::make_unique<LorentzTransformer>(); }
-      /// @returns This algorithm's class name
-      static std::string ClassName() { return "clas12::LorentzTransformer"; }
-
-      using Algorithm::Start;
-      void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks) const override;
-      void Stop() override;
 
       /// **Action function**: transform the 4-momentum @f$p=(p_x,p_y,p_z,E)@f$ to the specified frame
       /// @param px @f$p_x@f$
@@ -46,9 +35,6 @@ namespace iguana::clas12 {
           ) const;
 
     private:
-
-      /// True if this algorithm is registered in `AlgorithmFactory`
-      static bool s_registered;
 
       /// `hipo::banklist` index for the particle bank
       hipo::banklist::size_type b_particle;

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -8,6 +8,7 @@ algo_sources = [
 
 algo_public_headers = [
   'Algorithm.h',
+  'AlgorithmBoilerplate.h',
   'AlgorithmFactory.h',
   'AlgorithmSequence.h',
   'clas12/EventBuilderFilter.h',


### PR DESCRIPTION
To maintain consistency among the algorithms' boilerplate, and to reduce the amount of boilerplate that one needs to write in each algorithm, use preprocessor macros to generate the boilerplate. All macros are defined and documented in `AlgorithmBoilerplate.h`.