### PR TITLE
feat: set default buildtype to `release`, controllable in `configure.py`

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -24,6 +24,7 @@ parser_deps.add_argument( '--hipo', default=SYSTEM_ASSUMPTION, type=str, help='p
 parser_deps.add_argument( '--fmt', default=SYSTEM_ASSUMPTION, type=str, help='path to `fmt` installation')
 parser_build = parser.add_argument_group('build settings')
 parser_build.add_argument( '--prefix', default='iguana', type=str, help='iguana installation prefix')
+parser_build.add_argument( '--debug', default=False, action=argparse.BooleanOptionalAction, help='enable debugging symbols or not; optimization level is 0 if this is used, otherwise it is 3 (see also --buildtype)')
 parser_build.add_argument( '--examples', default=False, action=argparse.BooleanOptionalAction, help='build examples or not')
 parser_build.add_argument( '--documentation', default=False, action=argparse.BooleanOptionalAction, help='generate API documentation or not')
 parser_build = parser.add_argument_group('bindings')
@@ -31,6 +32,7 @@ parser_build.add_argument( '--python', default=False, action=argparse.BooleanOpt
 parser_build = parser.add_argument_group('advanced settings')
 parser_build.add_argument( '--build', default='build-iguana', type=str, help='iguana buildsystem directory')
 parser_build.add_argument( '--ini', default='build-iguana.ini', type=str, help='name of the output config INI file')
+parser_build.add_argument( '--buildtype', default='release', type=str, help='specify meson built-in option `buildtype`')
 args = parser.parse_args()
 
 # get prefix and source absolute paths
@@ -49,6 +51,9 @@ if(args.fmt != SYSTEM_ASSUMPTION):
     pkg_config_path.add(os.path.realpath(args.fmt) + '/lib/pkgconfig')
     pkg_config_deps.add('fmt')
 
+# set the buildtype
+buildtype = 'debug' if args.debug else args.buildtype
+
 # return an array of strings for meson's INI parsing
 def meson_string_array(arr):
     contents = ','.join(map(lambda s: f'\'{s}\'', arr))
@@ -63,12 +68,15 @@ if(len(cmake_prefix_path) > 0):
 if(len(pkg_config_path) > 0):
     config.set('built-in options', '; path to dependencies: ' + ','.join(pkg_config_deps))
     config.set('built-in options', 'pkg_config_path', meson_string_array(pkg_config_path))
-config.set('built-in options', '; installation settings')
-config.set('built-in options', 'prefix', f'\'{installDir}\'')
+config.set('built-in options', '; constant settings (do not edit)')
 config.set('built-in options', 'libdir', f'\'{LIBDIR}\'') # make all systems use LIBDIR
 config.set('built-in options', 'pkgconfig.relocatable', f'{PKGCONFIG_RELOCATABLE}')
+config.set('built-in options', '; build settings')
+config.set('built-in options', 'prefix', f'\'{installDir}\'')
+config.set('built-in options', 'buildtype', f'\'{buildtype}\'')
 config.set('built-in options', 'examples', f'{args.examples}')
 config.set('built-in options', 'documentation', f'{args.documentation}')
+config.set('built-in options', '; bindings')
 config.set('built-in options', 'bind_python', f'{args.python}')
 
 # write the INI file

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -22,4 +22,4 @@ Try enabling debugging symbols, either by:
 
 Then re-build `iguana`.
 
-Remember to revert this change and re-build, so that `iguana` runs with full optimization when you are processing large data sets (`buildtype = 'release').
+Remember to revert this change and re-build, so that `iguana` runs with full optimization when you are processing large data sets (`buildtype = 'release'`).

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -17,8 +17,9 @@ stdbuf -o0 myAnalysisProgram |& tee output.txt
 ## I got a crash, but the stack trace (or debugger) is not telling me exactly where
 
 Try enabling debugging symbols, either by:
-- use `--debug` in `configure.py`
-- set built-in option `buildtype` to `'debug'` in the build-configuration
-  `.ini` file (or in your `meson` command); see `meson` documentation for more details
+- set built-in option `buildtype` to `'debug'` in your build-configuration `.ini` file (or in your `meson` command)
+- use `--debug` when running `configure.py`
 
-Remember to revert this change and re-build, so that `iguana` runs with full optimization when you are processing large data sets.
+Then re-build `iguana`.
+
+Remember to revert this change and re-build, so that `iguana` runs with full optimization when you are processing large data sets (`buildtype = 'release').

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,6 +1,8 @@
 # Troubleshooting Notes
 
-- if you redirect `stdout` and `stderr` to a file, you may notice that `stderr` lines are out-of-order with respect to the `stdout` lines; for example:
+## My output appears to be out of order: errors are not printed exactly when they occur
+
+If you redirect `stdout` and `stderr` to a file, you may notice that `stderr` lines are out-of-order with respect to the `stdout` lines; for example:
 ```bash
 myAnalysisProgram                    # stdout and stderr print when they happen; ordering appears correct
 
@@ -11,3 +13,12 @@ To redirect output to a file with the ordering preserved, run your executable wi
 ```bash
 stdbuf -o0 myAnalysisProgram |& tee output.txt
 ```
+
+## I got a crash, but the stack trace (or debugger) is not telling me exactly where
+
+Try enabling debugging symbols, either by:
+- use `--debug` in `configure.py`
+- set built-in option `buildtype` to `'debug'` in the build-configuration
+  `.ini` file (or in your `meson` command); see `meson` documentation for more details
+
+Remember to revert this change and re-build, so that `iguana` runs with full optimization when you are processing large data sets.

--- a/src/iguana/algorithms/example/README.md
+++ b/src/iguana/algorithms/example/README.md
@@ -26,5 +26,5 @@ and get started coding!
 
 > [!TIP]
 > Enable debugging symbols when building, by either:
-> - use `--debug` in `configure.py`
-> - set built-in option `buildtype` to `'debug'` in the build-configuration `.ini` file (or in your `meson` command); see `meson` documentation for more details
+> - set built-in option `buildtype` to `'debug'` in your build-configuration `.ini` file (or in your `meson` command)
+> - use `--debug` when running `configure.py`

--- a/src/iguana/algorithms/example/README.md
+++ b/src/iguana/algorithms/example/README.md
@@ -23,3 +23,8 @@ src/iguana/algorithms/example/make_template.sh AwesomeAlgorithm clas12 src/iguan
 Once you have generated your new algorithm, add it to the appropriate
 `meson.build` file (likely [`src/iguana/algorithms/meson.build`](../meson.build)),
 and get started coding!
+
+> [!TIP]
+> Enable debugging symbols when building, by either:
+> - use `--debug` in `configure.py`
+> - set built-in option `buildtype` to `'debug'` in the build-configuration `.ini` file (or in your `meson` command); see `meson` documentation for more details


### PR DESCRIPTION
Meson's default build type is `debug`: enable debugging symbols and disable optimization.

We anticipate having more _users_ than algorithm developers, so let's set the default build type to `release` so that users will run optimized (faster) builds by default.

For developers, documentation has been added to encourage them to set the build type to `debug` when developing.