### PR TITLE
build: static link `hipo4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: checkout hipo
         uses: actions/checkout@v4
         with:
-          repository: mholtrop/hipo
+          repository: gavalian/hipo
           ref: ${{ env.hipo_version }}
       - name: build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ defaults:
     shell: bash
 
 env:
-  hipo_version: 4.0.1
+  hipo_version: test-maurik
   num_events: 10
 
 jobs:
@@ -80,7 +80,7 @@ jobs:
       - name: checkout hipo
         uses: actions/checkout@v4
         with:
-          repository: gavalian/hipo
+          repository: c-dilks/hipo
           ref: ${{ env.hipo_version }}
       - name: build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ defaults:
     shell: bash
 
 env:
-  hipo_version: master
+  hipo_version: f40da676bbd1745398e9fdf233ff213ff98798f1
   num_events: 10
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ defaults:
     shell: bash
 
 env:
-  hipo_version: use_pkgconfig_for_lz4
+  hipo_version: 4.0.1
   num_events: 10
 
 jobs:
@@ -80,7 +80,7 @@ jobs:
       - name: checkout hipo
         uses: actions/checkout@v4
         with:
-          repository: mholtrop/hipo
+          repository: gavalian/hipo
           ref: ${{ env.hipo_version }}
       - name: build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ defaults:
     shell: bash
 
 env:
-  hipo_version: test-maurik
+  hipo_version: master
   num_events: 10
 
 jobs:
@@ -80,7 +80,7 @@ jobs:
       - name: checkout hipo
         uses: actions/checkout@v4
         with:
-          repository: c-dilks/hipo
+          repository: mholtrop/hipo
           ref: ${{ env.hipo_version }}
       - name: build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ defaults:
     shell: bash
 
 env:
-  hipo_version: 4.0.1
+  hipo_version: use_pkgconfig_for_lz4
   num_events: 10
 
 jobs:
@@ -80,7 +80,7 @@ jobs:
       - name: checkout hipo
         uses: actions/checkout@v4
         with:
-          repository: gavalian/hipo
+          repository: mholtrop/hipo
           ref: ${{ env.hipo_version }}
       - name: build
         run: |

--- a/examples/build_with_cmake/CMakeLists.txt
+++ b/examples/build_with_cmake/CMakeLists.txt
@@ -12,11 +12,10 @@ if(NOT "${CMAKE_CXX_STANDARD}")
 endif()
 
 # find dependencies
-# - iguana doesn't create a `iguanaConfig.cmake` file, but it does create a pkg-config `.pc` file;
-#   using `PkgConfig`, the iguana target will be imported as `PkgConfig::iguana`
+# - using `PkgConfig` module imports pkg-config dependencies as targets prefixed with `PkgConfig::`
 # - if iguana was built with `static_hipo=True`, the `hipo4` target is not needed here
-find_package(hipo4 REQUIRED)
 find_package(PkgConfig REQUIRED)
+pkg_check_modules(hipo4 REQUIRED IMPORTED_TARGET hipo4)
 pkg_check_modules(iguana REQUIRED IMPORTED_TARGET iguana)
 
 # set the rpath to use the link path
@@ -28,5 +27,5 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(EXAMPLE_BIN iguana-example-00-basic)
 add_executable(${EXAMPLE_BIN})
 target_sources(${EXAMPLE_BIN} PRIVATE ${EXAMPLE_BIN}.cc)
-target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana hipo4)
+target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana PkgConfig::hipo4)
 install(TARGETS ${EXAMPLE_BIN})

--- a/examples/build_with_cmake/CMakeLists.txt
+++ b/examples/build_with_cmake/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 # find dependencies
 # - iguana doesn't create a `iguanaConfig.cmake` file, but it does create a pkg-config `.pc` file;
 #   using `PkgConfig`, the iguana target will be imported as `PkgConfig::iguana`
-find_package(hipo4 REQUIRED)
+# find_package(hipo4 REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(iguana REQUIRED IMPORTED_TARGET iguana)
 
@@ -27,5 +27,5 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(EXAMPLE_BIN iguana-example-00-basic)
 add_executable(${EXAMPLE_BIN})
 target_sources(${EXAMPLE_BIN} PRIVATE ${EXAMPLE_BIN}.cc)
-target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana hipo4)
+target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana)# hipo4)
 install(TARGETS ${EXAMPLE_BIN})

--- a/examples/build_with_cmake/CMakeLists.txt
+++ b/examples/build_with_cmake/CMakeLists.txt
@@ -15,7 +15,6 @@ endif()
 # - using `PkgConfig` module imports pkg-config dependencies as targets prefixed with `PkgConfig::`
 # - if iguana was built with `static_hipo=True`, the `hipo4` target is not needed here
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(hipo4 REQUIRED IMPORTED_TARGET hipo4)
 pkg_check_modules(iguana REQUIRED IMPORTED_TARGET iguana)
 
 # set the rpath to use the link path
@@ -27,5 +26,5 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(EXAMPLE_BIN iguana-example-00-basic)
 add_executable(${EXAMPLE_BIN})
 target_sources(${EXAMPLE_BIN} PRIVATE ${EXAMPLE_BIN}.cc)
-target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana PkgConfig::hipo4)
+target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana)
 install(TARGETS ${EXAMPLE_BIN})

--- a/examples/build_with_cmake/CMakeLists.txt
+++ b/examples/build_with_cmake/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 # - using `PkgConfig` module imports pkg-config dependencies as targets prefixed with `PkgConfig::`
 # - if iguana was built with `static_hipo=True`, the `hipo4` target is not needed here
 find_package(PkgConfig REQUIRED)
+pkg_check_modules(hipo4 REQUIRED IMPORTED_TARGET hipo4)
 pkg_check_modules(iguana REQUIRED IMPORTED_TARGET iguana)
 
 # set the rpath to use the link path
@@ -26,5 +27,5 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(EXAMPLE_BIN iguana-example-00-basic)
 add_executable(${EXAMPLE_BIN})
 target_sources(${EXAMPLE_BIN} PRIVATE ${EXAMPLE_BIN}.cc)
-target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana)
+target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana PkgConfig::hipo4)
 install(TARGETS ${EXAMPLE_BIN})

--- a/examples/build_with_cmake/CMakeLists.txt
+++ b/examples/build_with_cmake/CMakeLists.txt
@@ -13,7 +13,6 @@ endif()
 
 # find dependencies
 # - using `PkgConfig` module imports pkg-config dependencies as targets prefixed with `PkgConfig::`
-# - if iguana was built with `static_hipo=True`, the `hipo4` target is not needed here
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(hipo4 REQUIRED IMPORTED_TARGET hipo4)
 pkg_check_modules(iguana REQUIRED IMPORTED_TARGET iguana)

--- a/examples/build_with_cmake/CMakeLists.txt
+++ b/examples/build_with_cmake/CMakeLists.txt
@@ -14,7 +14,8 @@ endif()
 # find dependencies
 # - iguana doesn't create a `iguanaConfig.cmake` file, but it does create a pkg-config `.pc` file;
 #   using `PkgConfig`, the iguana target will be imported as `PkgConfig::iguana`
-# find_package(hipo4 REQUIRED)
+# - if iguana was built with `static_hipo=True`, the `hipo4` target is not needed here
+find_package(hipo4 REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(iguana REQUIRED IMPORTED_TARGET iguana)
 
@@ -27,5 +28,5 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(EXAMPLE_BIN iguana-example-00-basic)
 add_executable(${EXAMPLE_BIN})
 target_sources(${EXAMPLE_BIN} PRIVATE ${EXAMPLE_BIN}.cc)
-target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana)# hipo4)
+target_link_libraries(${EXAMPLE_BIN} PUBLIC PkgConfig::iguana hipo4)
 install(TARGETS ${EXAMPLE_BIN})

--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -8,14 +8,12 @@ project(
 # find dependencies
 # - it's good practice to specifiy minimum version requirements; here we just assume that `iguana` already did this
 # - if iguana was built with `static_hipo=True`, the `hipo4` dependency is not needed here
-hipo_dep   = dependency('hipo4')
 iguana_dep = dependency('iguana')
 
 # set rpath
 # - this is so that the executable knows where the dependency libraries are
 # - alternatively, set $LD_LIBRARY_PATH before running your executables ($DYLD_LIBRARY_PATH on macOS)
 bin_rpaths = [
-  hipo_dep.get_variable(pkgconfig: 'libdir'),
 ]
 if host_machine.system() != 'darwin'
   # FIXME(darwin): not sure how to set multiple rpaths on darwin executables, aside
@@ -33,7 +31,7 @@ example_bin = 'iguana-example-00-basic'
 executable(
   example_bin,
   example_bin + '.cc',
-  dependencies:  [hipo_dep, iguana_dep],
+  dependencies:  [iguana_dep],
   install:       true,
   install_rpath: ':'.join(bin_rpaths),
 )

--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -8,12 +8,14 @@ project(
 # find dependencies
 # - it's good practice to specifiy minimum version requirements; here we just assume that `iguana` already did this
 # - if iguana was built with `static_hipo=True`, the `hipo4` dependency is not needed here
+hipo_dep   = dependency('hipo4')
 iguana_dep = dependency('iguana')
 
 # set rpath
 # - this is so that the executable knows where the dependency libraries are
 # - alternatively, set $LD_LIBRARY_PATH before running your executables ($DYLD_LIBRARY_PATH on macOS)
 bin_rpaths = [
+  hipo_dep.get_variable(pkgconfig: 'libdir'),
 ]
 if host_machine.system() != 'darwin'
   # FIXME(darwin): not sure how to set multiple rpaths on darwin executables, aside
@@ -31,7 +33,7 @@ example_bin = 'iguana-example-00-basic'
 executable(
   example_bin,
   example_bin + '.cc',
-  dependencies:  [iguana_dep],
+  dependencies:  [hipo_dep, iguana_dep],
   install:       true,
   install_rpath: ':'.join(bin_rpaths),
 )

--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -7,7 +7,6 @@ project(
 
 # find dependencies
 # - it's good practice to specifiy minimum version requirements; here we just assume that `iguana` already did this
-# - if iguana was built with `static_hipo=True`, the `hipo4` dependency is not needed here
 hipo_dep   = dependency('hipo4')
 iguana_dep = dependency('iguana')
 

--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -7,6 +7,7 @@ project(
 
 # find dependencies
 # - it's good practice to specifiy minimum version requirements; here we just assume that `iguana` already did this
+# - if iguana was built with `static_hipo=True`, the `hipo4` dependency is not needed here
 hipo_dep   = dependency('hipo4')
 iguana_dep = dependency('iguana')
 

--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -14,7 +14,7 @@ iguana_dep = dependency('iguana')
 # - this is so that the executable knows where the dependency libraries are
 # - alternatively, set $LD_LIBRARY_PATH before running your executables ($DYLD_LIBRARY_PATH on macOS)
 bin_rpaths = [
-  hipo_dep.get_variable(pkgconfig: 'libdir'),
+  # hipo_dep.get_variable(pkgconfig: 'libdir'),
 ]
 if host_machine.system() != 'darwin'
   # FIXME(darwin): not sure how to set multiple rpaths on darwin executables, aside

--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -7,25 +7,16 @@ project(
 
 # find dependencies
 # - it's good practice to specifiy minimum version requirements; here we just assume that `iguana` already did this
-hipo_dep   = dependency('hipo4')
+hipo_dep   = dependency('hipo4', static: true) # use static link, for performance
 iguana_dep = dependency('iguana')
 
 # set rpath
 # - this is so that the executable knows where the dependency libraries are
 # - alternatively, set $LD_LIBRARY_PATH before running your executables ($DYLD_LIBRARY_PATH on macOS)
+# - not needed for libraries which are static-linked
 bin_rpaths = [
-  # hipo_dep.get_variable(pkgconfig: 'libdir'),
+  iguana_dep.get_variable(pkgconfig: 'libdir')
 ]
-if host_machine.system() != 'darwin'
-  # FIXME(darwin): not sure how to set multiple rpaths on darwin executables, aside
-  # from running `install_name_tool -add_rpath` post-installation; luckily,
-  # darwin-built examples only need `hipo_dep` libraries in the rpath and they
-  # don't need the `iguana` library path explictly included in the rpath, so
-  # this `if` block just keeps `bin_rpaths` to only one element. If we need
-  # more rpath elements someday, either we need to use `install_name_tool` or,
-  # preferably, resolution of https://github.com/mesonbuild/meson/issues/5760
-  bin_rpaths += iguana_dep.get_variable(pkgconfig: 'libdir')
-endif
 
 # build and install the executable
 example_bin = 'iguana-example-00-basic'

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ yamlcpp_dep = dependency(
 )
 hipo_dep = dependency(
   'hipo4',
-  static:  true,
+  static:  get_option('static_hipo'),
   method:  'pkg-config',
   version: '>=4.0.1',
 )

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,7 @@ yamlcpp_dep = dependency(
 )
 hipo_dep = dependency(
   'hipo4',
-  static:  get_option('static_hipo'),
+  static:  true,
   method:  'pkg-config',
   version: '>=4.0.1',
 )

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ yamlcpp_dep = dependency(
 )
 hipo_dep = dependency(
   'hipo4',
+  static:  true,
   method:  'pkg-config',
   version: '>=4.0.1',
 )

--- a/meson.build
+++ b/meson.build
@@ -68,17 +68,13 @@ project_pkg_vars  = [
 ]
 
 # executables' rpath
-project_exe_rpath = [
-  hipo_dep.get_variable(pkgconfig: 'libdir'),
-]
+project_exe_rpath = []
 if host_machine.system() != 'darwin'
-  # FIXME(darwin): not sure how to set multiple rpaths on darwin executables, aside
-  # from running `install_name_tool -add_rpath` post-installation; luckily,
-  # darwin-built examples only need `hipo_dep` libraries in the rpath and they
-  # don't need the `iguana` library path explictly included in the rpath, so
-  # this `if` block just keeps `project_exe_rpath` to only one element. If we need
-  # more rpath elements someday, either we need to use `install_name_tool` or,
-  # preferably, resolution of https://github.com/mesonbuild/meson/issues/5760
+  # FIXME(darwin): not sure how to set multiple rpaths on darwin executables,
+  # aside from running `install_name_tool -add_rpath` post-installation;
+  # luckily, darwin-built executables don't need the `iguana` library path
+  # explictly included in the rpath, so this `if` block just keeps
+  # `project_exe_rpath` minimal. See https://github.com/mesonbuild/meson/issues/5760
   project_exe_rpath += '$ORIGIN' / '..' / get_option('libdir')
 endif
 


### PR DESCRIPTION
Adds build option `static_hipo`, which if true, will link against static HIPO libraries.
- resolve #23 
- requires https://github.com/gavalian/hipo/pull/46