### PR TITLE
fix: build shared `fmt` libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: build
         if: ${{ inputs.runner != 'macos-latest' }}
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt -DBUILD_SHARED_LIBS=TRUE
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt -DBUILD_SHARED_LIBS=TRUE -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
           cmake --build build -j2
           cmake --install build
           tar czvf fmt{.tar.gz,}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: build
         if: ${{ inputs.runner != 'macos-latest' }}
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt -DBUILD_SHARED_LIBS=TRUE -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt -DBUILD_SHARED_LIBS=TRUE
           cmake --build build -j2
           cmake --install build
           tar czvf fmt{.tar.gz,}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ env.hipo_version }}
       - name: build
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=hipo
           cmake --build build -j2
           cmake --install build
           tar czvf hipo{.tar.gz,}
@@ -59,7 +59,7 @@ jobs:
       - name: build
         if: ${{ inputs.runner != 'macos-latest' }}
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=fmt -DBUILD_SHARED_LIBS=TRUE
           cmake --build build -j2
           cmake --install build
           tar czvf fmt{.tar.gz,}

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -38,7 +38,7 @@ python -m pip install meson ninja
 > ```bash
 > brew install fmt
 > ```
-- if you compile it yourself, include the `cmake` options `-DBUILD_SHARED_LIBS=TRUE` and `-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE`
+- if you compile it yourself, include the `cmake` option `-DBUILD_SHARED_LIBS=TRUE`
 - example `cmake` commands:
 ```bash
 cmake -S /path/to/fmt_source_code -B build-fmt -DCMAKE_INSTALL_PREFIX=/path/to/fmt_installation -DBUILD_SHARED_LIBS=TRUE -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -38,10 +38,10 @@ python -m pip install meson ninja
 > ```bash
 > brew install fmt
 > ```
-- if you compile it yourself, include the `cmake` option `-DCMAKE_POSITION_INDEPENDENT_CODE=ON`
+- if you compile it yourself, include the `cmake` options `-DBUILD_SHARED_LIBS=TRUE` and `-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE`
 - example `cmake` commands:
 ```bash
-cmake -S /path/to/fmt_source_code -B build-fmt -DCMAKE_INSTALL_PREFIX=/path/to/fmt_installation -DBUILD_SHARED_LIBS=TRUE
+cmake -S /path/to/fmt_source_code -B build-fmt -DCMAKE_INSTALL_PREFIX=/path/to/fmt_installation -DBUILD_SHARED_LIBS=TRUE -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
 cmake --build build-fmt -j$(nproc)
 cmake --install build-fmt
 ```

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -41,7 +41,7 @@ python -m pip install meson ninja
 - if you compile it yourself, include the `cmake` option `-DCMAKE_POSITION_INDEPENDENT_CODE=ON`
 - example `cmake` commands:
 ```bash
-cmake -S /path/to/fmt_source_code -B build-fmt -DCMAKE_INSTALL_PREFIX=/path/to/fmt_installation -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+cmake -S /path/to/fmt_source_code -B build-fmt -DCMAKE_INSTALL_PREFIX=/path/to/fmt_installation -DBUILD_SHARED_LIBS=TRUE
 cmake --build build-fmt -j$(nproc)
 cmake --install build-fmt
 ```

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -3,7 +3,7 @@ example_sources = [
   'iguana-example-01-bank-rows.cc',
 ]
 
-# add dependencies' libraries to rpath
+# add dependencies' shared libraries to rpath
 example_rpaths = [
   hipo_dep.get_variable(pkgconfig: 'libdir'),
 ]

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ project(
 project_description = 'Implementation Guardian of Analysis Algorithms'
 
 # resolve dependencies
-fmt_dep  = dependency('fmt',   version: '>=9.1.0', method: 'pkg-config')
+fmt_dep  = dependency('fmt',   version: '>=9.1.0', method: 'pkg-config', static: true)
 hipo_dep = dependency('hipo4', version: '>=4.0.1', method: 'pkg-config')
 
 # list of dependencies


### PR DESCRIPTION
See `fmt` build option documentation:
https://github.com/fmtlib/fmt/blob/bf98e3e4c61a7f5c36633278da6567f7bcedd4d5/doc/usage.rst?plain=1#L48-L60

~Resolves #75~ *no*, this should be a fallback if static `libfmt` doesn't exist

`cppyy` on macOS seems to rely on the shared (dynamic) `fmt` library, which wasn't being built on the CI or recommended in the documentation. In fact, the [Homebrew `fmt` formula](https://formulae.brew.sh/formula/fmt) builds both the static and dynamic libraries (whereas, e.g., [Arch Linux only builds the shared library](https://gitlab.archlinux.org/archlinux/packaging/packages/fmt).