### PR TITLE
fix: remove unnecessary things from test algorithms

### DIFF
--- a/bind/python/iguana-example-00-basic.py
+++ b/bind/python/iguana-example-00-basic.py
@@ -20,10 +20,11 @@ seq.Add('clas12::EventBuilderFilter')
 seq.Add('clas12::LorentzTransformer')
 seq.PrintSequence()
 
-seq.SetOption('clas12::EventBuilderFilter', 'log',  'trace')
+seq.SetOption('clas12::EventBuilderFilter', 'log',  'debug')
+seq.SetOption('clas12::LorentzTransformer', 'log',  'debug')
+
 seq.SetOption('clas12::EventBuilderFilter', 'pids', [11, 211, -211])
-seq.SetOption('clas12::EventBuilderFilter', 'testInt',   7)
-seq.SetOption('clas12::EventBuilderFilter', 'testFloat', 42.3)
+seq.SetOption('clas12::LorentzTransformer', 'frame', 'mirror')
 
 def prettyPrint(message, bank):
     print(f'{"="*30} {message} {"="*30}')

--- a/src/iguana/algorithms/clas12/EventBuilderFilter.cc
+++ b/src/iguana/algorithms/clas12/EventBuilderFilter.cc
@@ -8,12 +8,9 @@ namespace iguana::clas12 {
 
     // define options, their default values, and cache them
     CacheOptionToSet("pids", {11, 211}, o_pids);
-    CacheOption("testInt", 8, o_testInt); // TODO: remove
-    CacheOption("testFloat", 7.0, o_testFloat); // TODO: remove
 
     // cache expected bank indices
     CacheBankIndex(banks, "REC::Particle", b_particle);
-    CacheBankIndex(banks, "REC::Calorimeter", b_calo); // TODO: remove
 
   }
 
@@ -22,7 +19,6 @@ namespace iguana::clas12 {
 
     // get the banks
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
-    // auto& caloBank     = GetBank(banks, b_calo,     "REC::Calorimeter"); // TODO: remove
 
     // dump the bank
     ShowBank(particleBank, Logger::Header("INPUT PARTICLES"));
@@ -47,9 +43,6 @@ namespace iguana::clas12 {
 
 
   void EventBuilderFilter::Stop() {
-    m_log->Info("test info");
-    m_log->Warn("test warn");
-    m_log->Error("test error");
   }
 
 }

--- a/src/iguana/algorithms/clas12/EventBuilderFilter.h
+++ b/src/iguana/algorithms/clas12/EventBuilderFilter.h
@@ -23,12 +23,10 @@ namespace iguana::clas12 {
     private:
 
       /// `hipo::banklist` index for the particle bank
-      hipo::banklist::size_type b_particle, b_calo; // TODO: remove calorimeter
+      hipo::banklist::size_type b_particle;
 
       /// Configuration options
       std::set<int> o_pids;
-      int o_testInt; // TODO: remove
-      double o_testFloat; // TODO: remove
 
   };
 

--- a/src/iguana/algorithms/example/ExampleAlgorithm.cc
+++ b/src/iguana/algorithms/example/ExampleAlgorithm.cc
@@ -28,8 +28,8 @@ namespace iguana::example {
     //# - this function "caches" the option values into the `o_*` members, to
     //#   avoid looking them up in the `Algorithm::Run` method
     //############################################################################
-    CacheOption("testInt",   8,   o_testInt);
-    CacheOption("testFloat", 7.0, o_testFloat);
+    CacheOption("exampleInt",   8,   o_exampleInt);
+    CacheOption("exampleFloat", 7.0, o_exampleFloat);
     //############################################################################
     //# cache expected bank indices
     //# - here we make sure that parameter `banks` includes the banks that are

--- a/src/iguana/algorithms/example/ExampleAlgorithm.h
+++ b/src/iguana/algorithms/example/ExampleAlgorithm.h
@@ -97,9 +97,9 @@ namespace iguana::example {
       //# - convention: they should start with `o_`
       //############################################################################
       /// Example integer configuration option
-      int o_testInt;
+      int o_exampleInt;
       /// Example float configuration option
-      double o_testFloat;
+      double o_exampleFloat;
 
   };
 


### PR DESCRIPTION
We have been keeping some additional unused banks, options, and logging printouts; these were originally for testing infrastructure development. We don't need 'em any more.