### PR TITLE
doc: remove `nproc` suggestion

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -44,7 +44,7 @@ This includes [`ninja`](https://ninja-build.org/), which `meson` will benefit fr
 - Example `cmake` commands:
 ```bash
 cmake -S /path/to/hipo_source_code -B build-hipo -DCMAKE_INSTALL_PREFIX=/path/to/hipo_installation
-cmake --build build-hipo -j$(nproc)
+cmake --build build-hipo
 cmake --install build-hipo
 ```
 


### PR DESCRIPTION
Don't suggest users to run `cmake` with `-j$(nproc)`, since `nproc` does not exist on macOS (use `sysctl -n hw.ncpu` instead); those are just _example_ `cmake` commands anyway.