### PR TITLE
fix: move Lorentz vector types to `iguana` namespace in common header

### DIFF
--- a/src/iguana/algorithms/TypeDefs.h
+++ b/src/iguana/algorithms/TypeDefs.h
@@ -1,0 +1,14 @@
+/// @file
+/// @brief Type definitions for common objects used in algorithms
+
+#include <tuple>
+
+namespace iguana {
+
+  /// Lorentz vector element type, matching that of `REC::Particle` momentum components
+  using lorentz_element_t = float;
+
+  /// Generic Lorentz vector container type
+  using lorentz_vector_t = std::tuple<lorentz_element_t, lorentz_element_t, lorentz_element_t, lorentz_element_t>;
+
+}

--- a/src/iguana/algorithms/clas12/LorentzTransformer.cc
+++ b/src/iguana/algorithms/clas12/LorentzTransformer.cc
@@ -43,7 +43,7 @@ namespace iguana::clas12 {
   }
 
 
-  LorentzTransformer::lorentz_vector_t LorentzTransformer::Transform(
+  lorentz_vector_t LorentzTransformer::Transform(
       lorentz_element_t px,
       lorentz_element_t py,
       lorentz_element_t pz,

--- a/src/iguana/algorithms/clas12/LorentzTransformer.h
+++ b/src/iguana/algorithms/clas12/LorentzTransformer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "iguana/algorithms/Algorithm.h"
-#include <tuple>
+#include "iguana/algorithms/TypeDefs.h"
 
 namespace iguana::clas12 {
 
@@ -14,12 +14,6 @@ namespace iguana::clas12 {
     DEFINE_IGUANA_ALGORITHM(LorentzTransformer, clas12::LorentzTransformer)
 
     public:
-
-      /// Lorentz vector element type, matching that of `REC::Particle` momentum components
-      using lorentz_element_t = float;
-
-      /// Generic Lorentz vector container type
-      using lorentz_vector_t = std::tuple<lorentz_element_t, lorentz_element_t, lorentz_element_t, lorentz_element_t>;
 
       void Start(hipo::banklist& banks) override;
       void Run(hipo::banklist& banks) const override;

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -11,6 +11,7 @@ algo_public_headers = [
   'Algorithm.h',
   'AlgorithmBoilerplate.h',
   'AlgorithmSequence.h',
+  'TypeDefs.h',
   'example/ExampleAlgorithm.h',
   'clas12/EventBuilderFilter.h',
   'clas12/LorentzTransformer.h',


### PR DESCRIPTION
This allows other algorithms to use these types, and the ability to define other common types.

@asligonulacar, for #85 