### PR TITLE
feat: test examples with `meson test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
       - name: dump build options
         run: meson configure build-iguana | cat
       - name: meson install
-        run: meson install -C build-iguana
+        run: meson install -C build-iguana # must install, so the config files are in the expected location
       ### run tests
       - name: TEST algorithms
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ defaults:
 
 env:
   hipo_version: f40da676bbd1745398e9fdf233ff213ff98798f1
-  num_events: 10
+  num_events: 1000
   # sanitizer options; NOTE: suppression path assumes the build directory is a subdirectory of the top-level repo directory
   UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1:suppressions=../.github/UBSAN.supp
   ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_summary=1
@@ -253,9 +253,9 @@ jobs:
       ### re-build iguana
       - name: meson configure
         run: |
-          meson configure                          \
-            -Dtest_data_file=$(pwd)/test_data.hipo \
-            -Dtest_num_events=1000                 \
+          meson configure                           \
+            -Dtest_data_file=$(pwd)/test_data.hipo  \
+            -Dtest_num_events=${{ env.num_events }} \
             build-iguana
           case "${{ matrix.mode }}" in
             coverage)
@@ -308,10 +308,12 @@ jobs:
           path: coverage-report
 
   # run examples
+  # - a bit redundant, with `meson test` from `test_iguana`, but this ensures
+  #   the _installation_ works (e.g., `rpath` handling)
   #########################################################
 
   test_examples:
-    name: Test Examples
+    name: Test Installed Examples
     needs:
       - download_validation_files
       - build_iguana
@@ -378,12 +380,6 @@ jobs:
         run: iguana/bin/iguana-example-00-basic${{ matrix.extension }} test_data.hipo ${{ env.num_events }}
       - name: test 01
         run: iguana/bin/iguana-example-01-bank-rows${{ matrix.extension }} test_data.hipo ${{ env.num_events }}
-      - name: test 02
-        run: iguana/bin/iguana-example-02-YAMLReader${{ matrix.extension }}
-        if: ${{ matrix.id == 'cpp-gcc-release' }} #FIXME
-      - name: test 03
-        run: iguana/bin/iguana-example-03-zvertex-filter${{ matrix.extension }} test_data.hipo ${{ env.num_events }}
-        if: ${{ matrix.id == 'cpp-gcc-release' }} #FIXME
 
   # test consumers
   #########################################################

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,15 +1,33 @@
-example_sources = [
-  'iguana-example-00-basic.cc',
-  'iguana-example-01-bank-rows.cc',
-  'iguana-example-02-YAMLReader.cc',
-  'iguana-example-03-zvertex-filter.cc',
-]
+# install config files
+example_config_file = fs.copyfile(
+  'config' / 'ex2.yaml',
+  'ex2.yaml',
+  install:     true,
+  install_dir: project_etc / 'examples',
+)
 
-# build executables
-foreach src : example_sources
-  executable(
-    src.split('.')[0],
-    src,
+# example source information
+example_sources = {
+  'iguana-example-00-basic': {
+    'sources': [ 'iguana-example-00-basic.cc' ],
+  },
+  'iguana-example-01-bank-rows': {
+    'sources': [ 'iguana-example-01-bank-rows.cc' ],
+  },
+  'iguana-example-02-YAMLReader': {
+    'sources':   [ 'iguana-example-02-YAMLReader.cc' ],
+    'test_args': [ example_config_file.full_path() ],
+  },
+  'iguana-example-03-zvertex-filter': {
+    'sources': [ 'iguana-example-03-zvertex-filter.cc' ],
+  },
+}
+
+# build executables and test them
+foreach example, info : example_sources
+  example_exe = executable(
+    example,
+    sources:             info['sources'],
     include_directories: [ project_inc ] + ROOT_dep_inc_dirs,
     dependencies:        project_deps,
     link_with:           project_libs,
@@ -17,11 +35,14 @@ foreach src : example_sources
     install:             true,
     install_rpath:       ':'.join(project_exe_rpath),
   )
+  if fs.is_file(get_option('test_data_file'))
+    test(
+      example,
+      example_exe,
+      args: info.get(
+        'test_args',
+        [ get_option('test_data_file'), get_option('test_num_events') ]
+      ),
+    )
+  endif
 endforeach
-
-# install config files
-install_subdir(
-  'config',
-  install_dir:     project_etc / 'examples',
-  strip_directory: true,
-)


### PR DESCRIPTION
The examples have 0% coverage. This PR adds examples to `meson` tests, so that they are coverage tested.

The `test_examples` CI job will remain, since that one tests the _installed_ examples, whereas `meson test` tests the examples in the builddir; `test_examples` no longer has to test all the examples, just enough of them to give us confidence that the _installation_ is stable.