### PR TITLE
test: macOS `fmt` dynamic linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,9 @@ jobs:
           esac
       - name: dump build options
         run: meson configure build-iguana | cat
+      - name: tree fmt
+        run: tree /usr/local/Cellar/fmt
+        if: ${{ inputs.runner == 'macos-latest' }}
       - name: meson install
         run: meson install -C build-iguana # must install, so the config files are in the expected location
       ### run tests


### PR DESCRIPTION
macOS pipelines have been sporadically failing more frequently lately:

```
ninja: Entering directory `/Users/runner/work/iguana/iguana/build-iguana'
[0/1] Regenerating build files.
Cleaning... 0 files.
The Meson build system
Version: 1.3.2
Source dir: /Users/runner/work/iguana/iguana
Build dir: /Users/runner/work/iguana/iguana/build-iguana
Build type: native build
Project name: iguana
Project version: 0.3.0
C++ compiler for the host machine: g++ (clang 14.0.0 "Apple clang version 14.0.0 (clang-1400.0.29.202)")
C++ linker for the host machine: g++ ld64 820.1
Host machine cpu family: x86_64
Host machine cpu: x86_64
Dependency fmt found: YES 10.2.1 (cached)
Dependency yaml-cpp found: YES 0.8.0 (cached)
Dependency hipo4 found: YES 4.0.1 (cached)
Found CMake: /usr/local/bin/cmake (3.28.3)
Run-time dependency root found: NO (tried cmake)
Message: Dependency library dirs = [ /Users/runner/work/iguana/iguana/hipo/lib/pkgconfig/../../lib, /usr/local/Cellar/fmt/10.2.1_1/lib, /usr/local/Cellar/yaml-cpp/0.8.0/lib ]
Message: Dependency include dirs = [ /Users/runner/work/iguana/iguana/hipo/lib/pkgconfig/../../include, /usr/local/Cellar/fmt/10.2.1_1/include, /usr/local/Cellar/yaml-cpp/0.8.0/include ]
../src/iguana/algorithms/meson.build:58: WARNING: Excluding algorithm "clas12::LorentzTransformer", which depends on ROOT
Message: Test sample file provided; you may run tests with `meson test`
Found pkg-config: YES (/usr/local/bin/pkg-config) 0.29.2
Configuring this_iguana.sh using configuration
Build targets in project: 8

iguana 0.3.0

  User defined options
    buildtype      : release
    pkg_config_path: /Users/runner/work/iguana/iguana/hipo/lib/pkgconfig
    prefix         : /Users/runner/work/iguana/iguana/iguana
    documentation  : False
    examples       : True
    test_data_file : /Users/runner/work/iguana/iguana/test_data.hipo
    test_num_events: 1000

Found ninja-1.11.1 at /usr/local/bin/ninja
[1/26] Compiling C++ object src/iguana/services/libIguanaServices.dylib.p/Object.cc.o
[2/26] Compiling C++ object src/iguana/algorithms/libIguanaAlgorithms.dylib.p/AlgorithmFactory.cc.o
[3/26] Compiling C++ object src/iguana/services/libIguanaServices.dylib.p/Logger.cc.o
[4/26] Compiling C++ object src/iguana/services/libIguanaServices.dylib.p/YAMLReader.cc.o
[5/26] Compiling C++ object src/iguana/services/libIguanaServices.dylib.p/ConfigFileReader.cc.o
[6/26] Linking target src/iguana/services/libIguanaServices.dylib
FAILED: src/iguana/services/libIguanaServices.dylib 
g++  -o src/iguana/services/libIguanaServices.dylib src/iguana/services/libIguanaServices.dylib.p/Logger.cc.o src/iguana/services/libIguanaServices.dylib.p/Object.cc.o src/iguana/services/libIguanaServices.dylib.p/ConfigFileReader.cc.o src/iguana/services/libIguanaServices.dylib.p/YAMLReader.cc.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -shared -install_name @rpath/libIguanaServices.dylib -Wl,-rpath,/usr/local/Cellar/fmt/10.2.1/lib -Wl,-rpath,/usr/local/Cellar/yaml-cpp/0.8.0/lib /usr/local/Cellar/fmt/10.2.1/lib/libfmt.dylib /usr/local/Cellar/yaml-cpp/0.8.0/lib/libyaml-cpp.dylib /Users/runner/work/iguana/iguana/hipo/lib/pkgconfig/../../lib/libhipo4.a /usr/local/Cellar/lz4/1.9.4/lib/liblz4.a
clang: error: no such file or directory: '/usr/local/Cellar/fmt/10.2.1/lib/libfmt.dylib'
[7/26] Compiling C++ object src/iguana/algorithms/libIguanaAlgorithms.dylib.p/AlgorithmSequence.cc.o
[8/26] Compiling C++ object src/iguana/algorithms/libIguanaAlgorithms.dylib.p/example_ExampleAlgorithm.cc.o
[9/26] Compiling C++ object src/iguana/algorithms/libIguanaAlgorithms.dylib.p/Algorithm.cc.o
[10/26] Compiling C++ object src/iguana/algorithms/libIguanaAlgorithms.dylib.p/clas12_EventBuilderFilter.cc.o
[11/26] Compiling C++ object src/iguana/algorithms/libIguanaAlgorithms.dylib.p/clas12_ZVertexFilter.cc.o
ninja: build stopped: subcommand failed.
Could not rebuild /Users/runner/work/iguana/iguana/build-iguana
```

This PR investigates the issue