### PR TITLE
fix(ci): test ROOT-dependent algorithms

### DIFF
--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -19,6 +19,14 @@ GENERAL_PACKAGE_LIST_LINUX=(
   gcovr           # for coverage
   python-pygments # for coverage report syntax colors
   llvm            # for `llvm-symbolizer`, for human-readable sanitizer results
+  ### ROOT dependencies
+  binutils
+  libx11
+  libxpm
+  libxft
+  libxext
+  openssl
+  gsl
 )
 IGUANA_PACKAGE_LIST_LINUX=(
   fmt
@@ -32,6 +40,14 @@ GENERAL_PACKAGE_LIST_MACOS=(
   tree
   ninja
   meson
+  ### ROOT dependencies
+  binutils
+  libx11
+  libxpm
+  libxft
+  libxext
+  openssl
+  gsl
 )
 IGUANA_PACKAGE_LIST_MACOS=(
   fmt

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -13,6 +13,7 @@ GENERAL_PACKAGE_LIST_LINUX=(
   cmake
   tree
   wget
+  git
   which
   pkgconf
   ninja

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -12,6 +12,7 @@ GENERAL_PACKAGE_LIST_LINUX=(
   make
   cmake
   tree
+  wget
   which
   pkgconf
   ninja

--- a/.github/schedule-issue.md
+++ b/.github/schedule-issue.md
@@ -1,0 +1,6 @@
+---
+title: Weekly {{ env.WORKFLOW_ID }} pipeline failed on {{ date | date('dddd, MMMM Do, [at] HH:mm[Z]') }}
+---
+Workflow Run: {{ env.REPO_URL }}/actions/runs/{{ env.RUN_ID }}
+
+Please [check the cache](https://github.com/JeffersonLab/iguana/actions/caches), since weekly pipelines are scheduled to ensure cached dependency builds are up-to-date with respect to upstream.

--- a/.github/source-ROOT.sh
+++ b/.github/source-ROOT.sh
@@ -9,7 +9,8 @@ if [ $# -lt 2 ]; then
   USAGE: $0 [path/to/root] [runner] [OPTIONS]...
 
   OPTIONS:
-             ld   append ld path
+             ld          append (DY)LD_LIBRARY_PATH
+             python      append PYTHONPATH
 
   NOTE: this should only be used on the CI
   """
@@ -20,8 +21,12 @@ runner=$2
 shift
 shift
 set_ld_path=false
+set_python_path=false
 for arg in "$@"; do
-  [ "$arg" = "ld" ] && set_ld_path=true
+  case "$arg" in
+    ld)     set_ld_path=true     ;;
+    python) set_python_path=true ;;
+  esac
 done
 
 thisroot=$root_path/bin/thisroot.sh
@@ -33,9 +38,14 @@ fi
 source $thisroot
 
 echo PATH=$PATH >> $GITHUB_ENV
+
 if $set_ld_path; then
   case "$runner" in
     macos-latest) echo DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH >> $GITHUB_ENV ;;
     *)            echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH     >> $GITHUB_ENV ;;
   esac
+fi
+
+if $set_python_path; then
+  echo PYTHONPATH=$PYTHONPATH >> $GITHUB_ENV
 fi

--- a/.github/source-ROOT.sh
+++ b/.github/source-ROOT.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# source ROOT environment for CI
+set -e
+set -u
+
+# parse arguments
+if [ $# -lt 2 ]; then
+  echo """
+  USAGE: $0 [path/to/root] [runner] [OPTIONS]...
+
+  OPTIONS:
+             ld   append ld path
+
+  NOTE: this should only be used on the CI
+  """
+  exit 2
+fi
+root_path=$1
+runner=$2
+shift
+shift
+set_ld_path=false
+for arg in "$@"; do
+  [ "$arg" = "ld" ] && set_ld_path=true
+done
+
+thisroot=$root_path/bin/thisroot.sh
+if [ ! -f $thisroot ]; then
+  echo "ERROR: 'thisroot.sh' is not found at $thisroot" >&2
+  exit 1
+fi
+
+source $thisroot
+
+echo PATH=$PATH >> $GITHUB_ENV
+if $set_ld_path; then
+  case "$runner" in
+    macos-latest) echo DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH >> $GITHUB_ENV ;;
+    *)            echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH     >> $GITHUB_ENV ;;
+  esac
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,15 +233,14 @@ jobs:
           echo "| \`hipo\` | ${{ env.hipo_version }} |" >> $GITHUB_STEP_SUMMARY
           cat pkg_summary.md >> $GITHUB_STEP_SUMMARY
       - name: meson setup
-        run: meson setup build-iguana $(meson/resolve-dependencies.py --cli --hipo ./hipo)
-        # run: |
-        #   resolve_args=(--cli)
-        #   resolve_args+=(--hipo ./hipo)
-        #   [ "${{ matrix.build_id }}" != "cpp-gcc-release-noROOT" ] && resolve_args+=(--root ./root)
-        #   build_args=$(meson/resolve-dependencies.py ${resolve_args[@]})
-        #   echo "resolve_args = ${resolve_args[@]}"
-        #   echo "build_args   = $build_args"
-        #   meson setup build-iguana $build_args
+        run: |
+          resolve_args=(--cli)
+          resolve_args+=(--hipo ./hipo)
+          [ "${{ matrix.build_id }}" != "cpp-gcc-release-noROOT" ] && resolve_args+=(--root ./root)
+          build_args=$(meson/resolve-dependencies.py ${resolve_args[@]})
+          echo "resolve_args = ${resolve_args[@]}"
+          echo "build_args   = $build_args"
+          meson setup build-iguana $build_args
       - name: meson configure
         run: |
           meson configure                       \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,11 @@ jobs:
       - name: untar local dependencies
         run: ls *.tar.zst | xargs -I{} tar xvf {}
       ### rebuild iguana
+      - name: add `ROOT` to `PATH`
+        if: ${{ matrix.mode != 'noROOT' }}
+        run: |
+          source root/bin/thisroot.sh
+          echo PATH=$PATH >> $GITHUB_ENV # needed for `root-config`
       - name: meson wipe builddir for macOS re-link # macOS Homebrew installation prefix varies among runners, so wipe the builddir to force re-linking
         if: ${{ inputs.runner == 'macos-latest' }}
         run: meson setup build-iguana --wipe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,12 @@ on:
         default: >-
           {
             "include": [
-              { "mode": "coverage",                     "CC": "gcc",   "CXX": "g++",     "buildtype": "release" },
-              { "mode": "address sanitizer",            "CC": "clang", "CXX": "clang++", "buildtype": "debug"   },
-              { "mode": "thread sanitizer",             "CC": "clang", "CXX": "clang++", "buildtype": "debug"   },
-              { "mode": "undefined behavior sanitizer", "CC": "clang", "CXX": "clang++", "buildtype": "debug"   },
-              { "mode": "leak sanitizer",               "CC": "clang", "CXX": "clang++", "buildtype": "debug"   }
+              { "mode": "coverage",                     "build_id": "cpp-gcc-release",        "CC": "gcc",   "CXX": "g++",     "buildtype": "release" },
+              { "mode": "noROOT",                       "build_id": "cpp-gcc-release-noROOT", "CC": "gcc",   "CXX": "g++",     "buildtype": "release" },
+              { "mode": "address sanitizer",            "build_id": "cpp-clang-debug",        "CC": "clang", "CXX": "clang++", "buildtype": "debug"   },
+              { "mode": "thread sanitizer",             "build_id": "cpp-clang-debug",        "CC": "clang", "CXX": "clang++", "buildtype": "debug"   },
+              { "mode": "undefined behavior sanitizer", "build_id": "cpp-clang-debug",        "CC": "clang", "CXX": "clang++", "buildtype": "debug"   },
+              { "mode": "leak sanitizer",               "build_id": "cpp-clang-debug",        "CC": "clang", "CXX": "clang++", "buildtype": "debug"   }
             ]
           }
 
@@ -86,7 +87,7 @@ jobs:
       key: ${{ steps.key.outputs.key }}
     steps:
       - id: key
-        run: echo key=hipo-${{ inputs.id }}-${{ env.hipo_version }} >> $GITHUB_OUTPUT
+        run: echo key=hipo---${{ inputs.id }}---${{ env.hipo_version }}---$(date +%Y-week%U) >> $GITHUB_OUTPUT
       - uses: actions/cache/restore@v4
         id: cache
         with:
@@ -120,6 +121,7 @@ jobs:
           key: ${{ steps.key.outputs.key }}
           path: hipo.tar.zst
 
+
   build_root:
     name: Build ROOT
     runs-on: ${{ inputs.runner }}
@@ -128,36 +130,39 @@ jobs:
     outputs:
       key: ${{ steps.key.outputs.key }}
     steps:
+      - name: checkout iguana
+        uses: actions/checkout@v4
+        with:
+          path: iguana_src
       - id: key
-        run: echo key=root-${{ inputs.id }}-$(date +%Y-wk%V) >> $GITHUB_OUTPUT  # suffix: <YEAR>-wk<WEEKNUMBER>
+        run: |
+          root_version=$(iguana_src/meson/minimum-version.sh root src | sed 's;.*/;;' | sed 's;\.tar\.gz;;')
+          echo key=root---${{ inputs.id }}---${root_version}---$(date +%Y-week%U) >> $GITHUB_OUTPUT
       - uses: actions/cache/restore@v4
         id: cache
         with:
           key: ${{ steps.key.outputs.key }}
           path: root.tar.zst
           lookup-only: true
-      - name: checkout iguana for dependency installation script
+      - name: install dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v4
-        with:
-          path: iguana_src
-      - name: build ROOT
+        run: iguana_src/.github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
+      - name: download ROOT source code
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
-          echo "[+] INSTALL DEPENDENCIES"
-          iguana_src/.github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
           srcURL=$(iguana_src/meson/minimum-version.sh root src)
           echo "[+] DOWNLOADING ROOT SOURCE CODE FROM: $srcURL"
           wget -nv --no-check-certificate $srcURL
           tar xf $(ls -t *.gz | head -n1)
           ls -t
           mv -v $(ls -td root-* | head -n1) root_src
-          echo "[+] BUILDING ROOT"
+      - name: build ROOT
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: |
           cmake -S root_src -B build -G Ninja --install-prefix $(pwd)/root
           cmake --build build
           cmake --install build
-          echo "[+] MAKE TARBALL"
-          tar cavf root{.tar.zst,}
+          tar caf root{.tar.zst,}
       - uses: actions/cache/save@v4
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         id: cache_save
@@ -172,6 +177,7 @@ jobs:
     name: Build Iguana
     needs:
       - build_hipo
+      - build_root
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.container }}
@@ -180,12 +186,14 @@ jobs:
       matrix:
         include:
           # build C++-only version with various compilers and buildtypes
-          - { id: cpp-gcc-release,   CC: gcc,   CXX: g++,     buildtype: release, binding_opts: ''                   }
-          - { id: cpp-gcc-debug,     CC: gcc,   CXX: g++,     buildtype: debug,   binding_opts: ''                   }
-          - { id: cpp-clang-release, CC: clang, CXX: clang++, buildtype: release, binding_opts: ''                   }
-          - { id: cpp-clang-debug,   CC: clang, CXX: clang++, buildtype: debug,   binding_opts: ''                   }
+          - { build_id: cpp-gcc-release,        CC: gcc,   CXX: g++,     buildtype: release, binding_opts: '' }
+          - { build_id: cpp-gcc-debug,          CC: gcc,   CXX: g++,     buildtype: debug,   binding_opts: '' }
+          - { build_id: cpp-clang-release,      CC: clang, CXX: clang++, buildtype: release, binding_opts: '' }
+          - { build_id: cpp-clang-debug,        CC: clang, CXX: clang++, buildtype: debug,   binding_opts: '' }
+          # build without ROOT
+          - { build_id: cpp-gcc-release-noROOT, CC: gcc,   CXX: g++,     buildtype: release, binding_opts: '' }
           # build with bindings
-          - { id: python,            CC: gcc,   CXX: g++,     buildtype: release, binding_opts: '-Dbind_python=True' }
+          - { build_id: python,                 CC: gcc,   CXX: g++,     buildtype: release, binding_opts: '-Dbind_python=True' }
     env:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
@@ -204,12 +212,18 @@ jobs:
         with:
           key: ${{ needs.build_hipo.outputs.key }}
           path: hipo.tar.zst
+      - name: get local dependency `ROOT`
+        if: ${{ matrix.build_id != 'cpp-gcc-release-noROOT' }}
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.build_root.outputs.key }}
+          path: root.tar.zst
       - name: untar local dependencies
         run: ls *.tar.zst | xargs -I{} tar xvf {}
       - name: tree local dependencies
         run: tree hipo
       - name: summarize dependencies
-        if: ${{ matrix.id == 'cpp-gcc-release' }}
+        if: ${{ matrix.build_id == 'cpp-gcc-release' }}
         run: |
           echo '### Dependencies' >> $GITHUB_STEP_SUMMARY
           echo '| Dependency | Version |' >> $GITHUB_STEP_SUMMARY
@@ -236,7 +250,7 @@ jobs:
         if: always()
         run: cat build-iguana/meson-logs/meson-log.txt
       - name: readelf/otool iguana examples
-        if: ${{ matrix.id == 'cpp-gcc-release' || matrix.id == 'cpp-gcc-debug' || matrix.id == 'cpp-clang-release' || matrix.id == 'cpp-clang-debug' }}
+        if: ${{ matrix.binding_opts = '' }}
         run: |
           binaries=$(find iguana/bin -type f -name "iguana-example-*")
           libraries=$(find iguana -type f -name "*.so")
@@ -263,13 +277,12 @@ jobs:
           tar cavf build-iguana{.tar.zst,}
       - uses: actions/upload-artifact@v4
         with:
-          name: install_iguana_${{ matrix.id }}
+          name: install_iguana_${{ matrix.build_id }}
           retention-days: 1
           path: iguana.tar.zst
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.id == 'cpp-gcc-release' || matrix.id == 'cpp-gcc-debug' || matrix.id == 'cpp-clang-release' || matrix.id == 'cpp-clang-debug' }}
         with:
-          name: build_iguana_${{ matrix.id }}
+          name: build_iguana_${{ matrix.build_id }}
           retention-days: 1
           path: build-iguana.tar.zst
 
@@ -280,6 +293,7 @@ jobs:
     name: Test Iguana
     needs:
       - build_hipo
+      - build_root
       - download_test_data
       - build_iguana
     runs-on: ${{ inputs.runner }}
@@ -291,7 +305,6 @@ jobs:
     env:
       CC: ${{ matrix.CC }}
       CXX: ${{ matrix.CXX }}
-      build_id: ${{ matrix.CC }}-${{ matrix.buildtype }}
     steps:
       ### setup
       - uses: actions/checkout@v4
@@ -307,7 +320,7 @@ jobs:
       - name: get iguana build dir
         uses: actions/download-artifact@v4
         with:
-          name: build_iguana_cpp-${{ env.build_id }}
+          name: build_iguana_${{ matrix.build_id }}
       ### dependencies
       - name: install dependency packages
         run: .github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
@@ -316,6 +329,12 @@ jobs:
         with:
           key: ${{ needs.build_hipo.outputs.key }}
           path: hipo.tar.zst
+      - name: get local dependency `ROOT`
+        if: ${{ matrix.mode != 'noROOT' }}
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.build_root.outputs.key }}
+          path: root.tar.zst
       - name: untar local dependencies
         run: ls *.tar.zst | xargs -I{} tar xvf {}
       ### rebuild iguana
@@ -388,6 +407,7 @@ jobs:
     needs:
       - download_test_data
       - build_hipo
+      - build_root
       - build_iguana
     runs-on: ${{ inputs.runner }}
     container:
@@ -396,8 +416,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { id: cpp-gcc-release, extension: ''    }
-          - { id: python,          extension: '.py' }
+          - { build_id: cpp-gcc-release, extension: ''    }
+          - { build_id: python,          extension: '.py' }
     steps:
       ### dependencies and test data
       - uses: actions/checkout@v4
@@ -411,10 +431,15 @@ jobs:
         with:
           key: ${{ needs.build_hipo.outputs.key }}
           path: hipo.tar.zst
+      - name: get local dependency `ROOT`
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.build_root.outputs.key }}
+          path: root.tar.zst
       - name: get iguana build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: install_iguana_${{ matrix.id }}
+          name: install_iguana_${{ matrix.build_id }}
       - name: get test data
         uses: actions/cache/restore@v4
         with:
@@ -428,7 +453,7 @@ jobs:
         run: tree
       ### setup python virtaul environment (for python binding tests)
       - name: install python binding runtime dependencies
-        if: ${{ matrix.id == 'python' }}
+        if: ${{ matrix.build_id == 'python' }}
         run: |
           python -m venv .venv
           source .venv/bin/activate
@@ -436,13 +461,13 @@ jobs:
           python -m pip install -r iguana_src/bind/python/requirements.txt
       ### set env vars - depends on runner and binding
       - name: source environment for Linux and python
-        if: ${{ inputs.runner == 'ubuntu-latest' && matrix.id == 'python' }}
+        if: ${{ inputs.runner == 'ubuntu-latest' && matrix.build_id == 'python' }}
         run: |
           source iguana/bin/this_iguana.sh verbose
           echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH >> $GITHUB_ENV
           echo PYTHONPATH=$PYTHONPATH           >> $GITHUB_ENV
       - name: source environment for macOS and python
-        if: ${{ inputs.runner == 'macos-latest' && matrix.id == 'python' }}
+        if: ${{ inputs.runner == 'macos-latest' && matrix.build_id == 'python' }}
         run: |
           source iguana/bin/this_iguana.sh verbose ld
           echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH     >> $GITHUB_ENV
@@ -462,6 +487,7 @@ jobs:
     needs:
       - download_test_data
       - build_hipo
+      - build_root
       - build_iguana
     runs-on: ${{ inputs.runner }}
     container:
@@ -471,6 +497,8 @@ jobs:
       matrix:
         tool: [ cmake, make, meson ]
     env:
+      CC: gcc
+      CXX: g++
       build_id: cpp-gcc-release
     steps:
       ### dependencies and test data
@@ -482,6 +510,11 @@ jobs:
         with:
           key: ${{ needs.build_hipo.outputs.key }}
           path: hipo.tar.zst
+      - name: get local dependency `ROOT`
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.build_root.outputs.key }}
+          path: root.tar.zst
       - name: get iguana build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -520,7 +553,7 @@ jobs:
   #########################################################
 
   doc_generate:
-    if: ${{ inputs.runner == 'ubuntu-latest' && inputs.verset == 'latest' }}
+    if: ${{ inputs.id == 'linux-latest' }}
     name: Generate documentation
     runs-on: ${{ inputs.runner }}
     steps:
@@ -539,7 +572,7 @@ jobs:
   #########################################################
 
   collect_webpages:
-    if: ${{ (github.head_ref == 'main' || github.ref_name == 'main') && inputs.runner == 'ubuntu-latest' && inputs.verset == 'latest' }}
+    if: ${{ (github.head_ref == 'main' || github.ref_name == 'main') && inputs.id == 'linux-latest' }}
     name: Collect webpages
     needs:
       - doc_generate
@@ -573,7 +606,7 @@ jobs:
           path: pages/
 
   deploy_webpages:
-    if: ${{ (github.head_ref == 'main' || github.ref_name == 'main') && inputs.runner == 'ubuntu-latest' && inputs.verset == 'latest' }}
+    if: ${{ (github.head_ref == 'main' || github.ref_name == 'main') && inputs.id == 'linux-latest' }}
     name: Deploy webpages
     needs: collect_webpages
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,10 @@ jobs:
             build-iguana
       - name: require ROOT
         if: ${{ matrix.build_id != 'cpp-gcc-release-noROOT' }}
-        run: meson configure -Drequire_ROOT=true build-iguana
+        run: |
+          meson configure -Drequire_ROOT=true build-iguana
+          source root/bin/thisroot.sh
+          echo PATH=$PATH >> $GITHUB_ENV # add `root-config` to PATH
       - name: dump build options
         run: meson configure build-iguana | cat
       - name: meson install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
           echo PYTHONPATH=$PYTHONPATH               >> $GITHUB_ENV
           echo DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH >> $GITHUB_ENV  # for cppyy on macOS to be able to find dynamic libs
       - name: source environment for ROOT
-        run: iguana_src/.github/source-ROOT.sh root ${{ inputs.runner }} ld # needed for `ld` path
+        run: iguana_src/.github/source-ROOT.sh root ${{ inputs.runner }} ld python # needed for `ld` path and PYTHONPATH
       ### run tests
       - name: test 00
         run: iguana/bin/iguana-example-00-basic${{ matrix.extension }} test_data.hipo ${{ env.num_events }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,11 @@ jobs:
         with:
           key: ${{ needs.build_root.outputs.key }}
           path: root.tar.zst
+      - name: add `ROOT` to `PATH`
+        if: ${{ matrix.build_id != 'cpp-gcc-release-noROOT' }}
+        run: |
+          source root/bin/thisroot.sh
+          echo PATH=$PATH >> $GITHUB_ENV # needed for `root-config`
       - name: untar local dependencies
         run: ls *.tar.zst | xargs -I{} tar xvf {}
       - name: tree local dependencies
@@ -252,10 +257,7 @@ jobs:
             build-iguana
       - name: require ROOT
         if: ${{ matrix.build_id != 'cpp-gcc-release-noROOT' }}
-        run: |
-          meson configure -Drequire_ROOT=true build-iguana
-          source root/bin/thisroot.sh
-          echo PATH=$PATH >> $GITHUB_ENV # add `root-config` to PATH
+        run: meson configure -Drequire_ROOT=true build-iguana
       - name: dump build options
         run: meson configure build-iguana | cat
       - name: meson install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,9 +206,10 @@ jobs:
           clean: false
           fetch-tags: true
           fetch-depth: 0
+          path: iguana_src
       ### dependencies
       - name: install dependency packages
-        run: .github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
+        run: iguana_src/.github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
       - name: get local dependency `hipo`
         uses: actions/cache/restore@v4
         with:
@@ -243,10 +244,10 @@ jobs:
           resolve_args=(--cli)
           resolve_args+=(--hipo ./hipo)
           [ "${{ matrix.build_id }}" != "cpp-gcc-release-noROOT" ] && resolve_args+=(--root ./root)
-          build_args=$(meson/resolve-dependencies.py ${resolve_args[@]})
+          build_args=$(iguana_src/meson/resolve-dependencies.py ${resolve_args[@]})
           echo "resolve_args = ${resolve_args[@]}"
           echo "build_args   = $build_args"
-          meson setup build-iguana $build_args
+          meson setup build-iguana iguana_src $build_args
       - name: meson configure
         run: |
           meson configure                       \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,7 @@ jobs:
         if: always()
         run: cat build-iguana/meson-logs/meson-log.txt
       - name: readelf/otool iguana examples
-        if: ${{ matrix.binding_opts = '' }}
+        if: ${{ matrix.binding_opts == '' }}
         run: |
           binaries=$(find iguana/bin -type f -name "iguana-example-*")
           libraries=$(find iguana -type f -name "*.so")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,7 @@ jobs:
         if: ${{ matrix.tool == 'cmake' }}
         run: echo CMAKE_PREFIX_PATH=$(pwd)/hipo >> $GITHUB_ENV
       - name: source environment for ROOT
-        run: iguana_src/.github/source-ROOT.sh root ${{ inputs.runner }} ld # needed for `ld` path
+        run: .github/source-ROOT.sh root ${{ inputs.runner }} ld # needed for `ld` path
       ### build test
       - name: build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,9 @@ jobs:
           srcURL=$(iguana_src/meson/minimum-version.sh root src)
           echo "[+] DOWNLOADING ROOT SOURCE CODE FROM: $srcURL"
           wget -nv --no-check-certificate $srcURL
-          tar xvf root_*.tar.gz
-          mv -v $(ls -d root-* | head -n1) root_src
+          tar xf $(ls -t *.gz | head -n1)
+          ls -t
+          mv -v $(ls -td root-* | head -n1) root_src
           echo "[+] BUILDING ROOT"
           cmake -S root_src -B build -G Ninja --install-prefix $(pwd)/root
           cmake --build build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,14 @@ jobs:
           cat pkg_summary.md >> $GITHUB_STEP_SUMMARY
       - name: meson setup
         run: meson setup build-iguana $(meson/resolve-dependencies.py --cli --hipo ./hipo)
+        # run: |
+        #   resolve_args=(--cli)
+        #   resolve_args+=(--hipo ./hipo)
+        #   [ "${{ matrix.build_id }}" != "cpp-gcc-release-noROOT" ] && resolve_args+=(--root ./root)
+        #   build_args=$(meson/resolve-dependencies.py ${resolve_args[@]})
+        #   echo "resolve_args = ${resolve_args[@]}"
+        #   echo "build_args   = $build_args"
+        #   meson setup build-iguana $build_args
       - name: meson configure
         run: |
           meson configure                       \
@@ -241,6 +249,9 @@ jobs:
             -Ddocumentation=False               \
             ${{ matrix.binding_opts }}          \
             build-iguana
+      - name: require ROOT
+        if: ${{ matrix.build_id != 'cpp-gcc-release-noROOT' }}
+        run: meson configure -Drequire_ROOT=true build-iguana
       - name: dump build options
         run: meson configure build-iguana | cat
       - name: meson install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,9 +236,7 @@ jobs:
       ### build
       - name: add `ROOT` to `PATH`
         if: ${{ matrix.build_id != 'cpp-gcc-release-noROOT' }}
-        run: |
-          source root/bin/thisroot.sh
-          echo PATH=$PATH >> $GITHUB_ENV # needed for `root-config`
+        run: iguana_src/.github/source-ROOT.sh root ${{ inputs.runner }} # needed for `root-config`
       - name: meson setup
         run: |
           resolve_args=(--cli)
@@ -358,11 +356,9 @@ jobs:
       - name: untar local dependencies
         run: ls *.tar.zst | xargs -I{} tar xvf {}
       ### rebuild iguana
-      - name: add `ROOT` to `PATH`
+      - name: add `ROOT` to `PATH` and `ld` path
         if: ${{ matrix.mode != 'noROOT' }}
-        run: |
-          source root/bin/thisroot.sh
-          echo PATH=$PATH >> $GITHUB_ENV # needed for `root-config`
+        run: iguana_src/.github/source-ROOT.sh root ${{ inputs.runner }} ld # needed for `root-config` and `ld` path
       - name: meson wipe builddir for macOS re-link # macOS Homebrew installation prefix varies among runners, so wipe the builddir to force re-linking
         if: ${{ inputs.runner == 'macos-latest' }}
         run: meson setup build-iguana --wipe
@@ -499,12 +495,7 @@ jobs:
           echo PYTHONPATH=$PYTHONPATH               >> $GITHUB_ENV
           echo DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH >> $GITHUB_ENV  # for cppyy on macOS to be able to find dynamic libs
       - name: source environment for ROOT
-        run: |
-          source root/bin/thisroot.sh
-          case "${{ inputs.runner }}" in
-            macos-latest) echo DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH >> $GITHUB_ENV ;;
-            *)            echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH >> $GITHUB_ENV ;;
-          esac
+        run: iguana_src/.github/source-ROOT.sh root ${{ inputs.runner }} ld # needed for `ld` path
       ### run tests
       - name: test 00
         run: iguana/bin/iguana-example-00-basic${{ matrix.extension }} test_data.hipo ${{ env.num_events }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ env:
   hipo_version: f40da676bbd1745398e9fdf233ff213ff98798f1
   num_events: 1000
   # sanitizer options; NOTE: suppression path assumes the build directory is a subdirectory of the top-level repo directory
-  UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1:suppressions=../.github/UBSAN.supp
+  UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1:suppressions=../iguana_src/.github/UBSAN.supp
   ASAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_summary=1
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,7 @@ jobs:
           clean: false
           fetch-tags: true
           fetch-depth: 0
+          path: iguana_src
       - name: get test data
         uses: actions/cache/restore@v4
         with:
@@ -342,7 +343,7 @@ jobs:
           name: build_iguana_${{ matrix.build_id }}
       ### dependencies
       - name: install dependency packages
-        run: .github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
+        run: iguana_src/.github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
       - name: get local dependency `hipo`
         uses: actions/cache/restore@v4
         with:
@@ -492,6 +493,13 @@ jobs:
           echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH     >> $GITHUB_ENV
           echo PYTHONPATH=$PYTHONPATH               >> $GITHUB_ENV
           echo DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH >> $GITHUB_ENV  # for cppyy on macOS to be able to find dynamic libs
+      - name: source environment for ROOT
+        run: |
+          source root/bin/thisroot.sh
+          case "${{ inputs.runner }}" in
+            macos-latest) echo DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH >> $GITHUB_ENV ;;
+            *)            echo LD_LIBRARY_PATH=$LD_LIBRARY_PATH >> $GITHUB_ENV ;;
+          esac
       ### run tests
       - name: test 00
         run: iguana/bin/iguana-example-00-basic${{ matrix.extension }} test_data.hipo ${{ env.num_events }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,11 +220,6 @@ jobs:
         with:
           key: ${{ needs.build_root.outputs.key }}
           path: root.tar.zst
-      - name: add `ROOT` to `PATH`
-        if: ${{ matrix.build_id != 'cpp-gcc-release-noROOT' }}
-        run: |
-          source root/bin/thisroot.sh
-          echo PATH=$PATH >> $GITHUB_ENV # needed for `root-config`
       - name: untar local dependencies
         run: ls *.tar.zst | xargs -I{} tar xvf {}
       - name: tree local dependencies
@@ -237,6 +232,12 @@ jobs:
           echo '| --- | --- |' >> $GITHUB_STEP_SUMMARY
           echo "| \`hipo\` | ${{ env.hipo_version }} |" >> $GITHUB_STEP_SUMMARY
           cat pkg_summary.md >> $GITHUB_STEP_SUMMARY
+      ### build
+      - name: add `ROOT` to `PATH`
+        if: ${{ matrix.build_id != 'cpp-gcc-release-noROOT' }}
+        run: |
+          source root/bin/thisroot.sh
+          echo PATH=$PATH >> $GITHUB_ENV # needed for `root-config`
       - name: meson setup
         run: |
           resolve_args=(--cli)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           echo "[+] DOWNLOADING ROOT SOURCE CODE FROM: $srcURL"
           wget -nv --no-check-certificate $srcURL
           tar xvf root_*.tar.gz
-          mv -v $(ls -d root_* | head -n1) root_src
+          mv -v $(ls -d root-* | head -n1) root_src
           echo "[+] BUILDING ROOT"
           cmake -S root_src -B build -G Ninja --install-prefix $(pwd)/root
           cmake --build build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,7 +558,7 @@ jobs:
       ### build test
       - name: build
         run: |
-          source iguana/bin/this_iguana.sh verbose
+          source iguana/bin/this_iguana.sh verbose ld # `ld` is needed for ROOT
           .github/test-consumer-build.sh ${{ matrix.tool }}
       - name: readelf/otool executable
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,20 @@ jobs:
           key: hipo-${{ inputs.id }}-${{ env.hipo_version }}
           path: hipo.tar.zst
 
+  test_root:
+    name: test ROOT
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.container }}
+    steps:
+      - uses: cvmfs-contrib/github-action-cvmfs@v4
+        run: |
+          ls /cvmfs/sft.cern.ch
+          echo "==="
+          ls /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.28.10/x86_64-ubuntu22-gcc114-opt
+          echo "==="
+          ls /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.28.10/x86_64-mac127-clang140-opt
+
   # build
   #########################################################
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,15 @@ jobs:
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.container }}
+    outputs:
+      key: ${{ steps.key.outputs.key }}
     steps:
+      - id: key
+        run: echo key=hipo-${{ inputs.id }}-${{ env.hipo_version }} >> $GITHUB_OUTPUT
       - uses: actions/cache/restore@v4
         id: cache
         with:
-          key: hipo-${{ inputs.id }}-${{ env.hipo_version }}
+          key: ${{ steps.key.outputs.key }}
           path: hipo.tar.zst
           lookup-only: true
       - name: checkout iguana for dependency installation script
@@ -113,19 +117,50 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         id: cache_save
         with:
-          key: hipo-${{ inputs.id }}-${{ env.hipo_version }}
+          key: ${{ steps.key.outputs.key }}
           path: hipo.tar.zst
 
-  test_root:
-    name: test ROOT
+  build_root:
+    name: Build ROOT
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.container }}
+    outputs:
+      key: ${{ steps.key.outputs.key }}
     steps:
-      - uses: cvmfs-contrib/github-action-cvmfs@v4
-      - run: ls /cvmfs/sft.cern.ch
-      - run: ls /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.28.10/x86_64-ubuntu22-gcc114-opt
-      - run: ls /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.28.10/x86_64-mac127-clang140-opt
+      - id: key
+        run: echo key=root-${{ inputs.id }}-$(date +%Y-wk%V) >> $GITHUB_OUTPUT  # suffix: <YEAR>-wk<WEEKNUMBER>
+      - uses: actions/cache/restore@v4
+        id: cache
+        with:
+          key: ${{ steps.key.outputs.key }}
+          path: root.tar.zst
+          lookup-only: true
+      - name: checkout iguana for dependency installation script
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@v4
+        with:
+          path: iguana_src
+      - name: build ROOT
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run:
+          srcURL=$(iguana_src/meson/minimum-version.sh root src)
+          echo "[+] DOWNLOADING ROOT SOURCE CODE FROM: $srcURL"
+          wget -nv --no-check-certificate $srcURL
+          tar xvf root_*.tar.gz
+          mv -v $(ls -d root_* | head -n1) root_src
+          echo "[+] BUILDING ROOT"
+          cmake -S root_src -B build -G Ninja --install-prefix $(pwd)/root
+          cmake --build build
+          cmake --install build
+          echo "[+] MAKE TARBALL"
+          tar cavf root{.tar.zst,}
+      - uses: actions/cache/save@v4
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        id: cache_save
+        with:
+          key: ${{ steps.key.outputs.key }}
+          path: root.tar.zst
 
   # build
   #########################################################
@@ -164,7 +199,7 @@ jobs:
       - name: get local dependency `hipo`
         uses: actions/cache/restore@v4
         with:
-          key: hipo-${{ inputs.id }}-${{ env.hipo_version }}
+          key: ${{ needs.build_hipo.outputs.key }}
           path: hipo.tar.zst
       - name: untar local dependencies
         run: ls *.tar.zst | xargs -I{} tar xvf {}
@@ -276,7 +311,7 @@ jobs:
       - name: get local dependency `hipo`
         uses: actions/cache/restore@v4
         with:
-          key: hipo-${{ inputs.id }}-${{ env.hipo_version }}
+          key: ${{ needs.build_hipo.outputs.key }}
           path: hipo.tar.zst
       - name: untar local dependencies
         run: ls *.tar.zst | xargs -I{} tar xvf {}
@@ -349,6 +384,7 @@ jobs:
     name: Test Installed Examples
     needs:
       - download_test_data
+      - build_hipo
       - build_iguana
     runs-on: ${{ inputs.runner }}
     container:
@@ -370,7 +406,7 @@ jobs:
       - name: get local dependency `hipo`
         uses: actions/cache/restore@v4
         with:
-          key: hipo-${{ inputs.id }}-${{ env.hipo_version }}
+          key: ${{ needs.build_hipo.outputs.key }}
           path: hipo.tar.zst
       - name: get iguana build artifacts
         uses: actions/download-artifact@v4
@@ -422,6 +458,7 @@ jobs:
     name: Test consumer builds
     needs:
       - download_test_data
+      - build_hipo
       - build_iguana
     runs-on: ${{ inputs.runner }}
     container:
@@ -440,7 +477,7 @@ jobs:
       - name: get local dependency `hipo`
         uses: actions/cache/restore@v4
         with:
-          key: hipo-${{ inputs.id }}-${{ env.hipo_version }}
+          key: ${{ needs.build_hipo.outputs.key }}
           path: hipo.tar.zst
       - name: get iguana build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,8 @@ jobs:
       - name: build ROOT
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
+          echo "[+] INSTALL DEPENDENCIES"
+          iguana_src/.github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
           srcURL=$(iguana_src/meson/minimum-version.sh root src)
           echo "[+] DOWNLOADING ROOT SOURCE CODE FROM: $srcURL"
           wget -nv --no-check-certificate $srcURL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
           path: iguana_src
       - name: build ROOT
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run:
+        run: |
           srcURL=$(iguana_src/meson/minimum-version.sh root src)
           echo "[+] DOWNLOADING ROOT SOURCE CODE FROM: $srcURL"
           wget -nv --no-check-certificate $srcURL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: build ROOT
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
-          cmake -S root_src -B build -G Ninja --install-prefix $(pwd)/root
+          cmake -S root_src -B build -G Ninja --install-prefix $(pwd)/root -DCMAKE_CXX_STANDARD=17
           cmake --build build
           cmake --install build
           tar caf root{.tar.zst,}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,10 +555,12 @@ jobs:
       - name: set cmake prefix path
         if: ${{ matrix.tool == 'cmake' }}
         run: echo CMAKE_PREFIX_PATH=$(pwd)/hipo >> $GITHUB_ENV
+      - name: source environment for ROOT
+        run: iguana_src/.github/source-ROOT.sh root ${{ inputs.runner }} ld # needed for `ld` path
       ### build test
       - name: build
         run: |
-          source iguana/bin/this_iguana.sh verbose ld # `ld` is needed for ROOT
+          source iguana/bin/this_iguana.sh verbose
           .github/test-consumer-build.sh ${{ matrix.tool }}
       - name: readelf/otool executable
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
         run: iguana_src/.github/source-ROOT.sh root ${{ inputs.runner }} ld # needed for `root-config` and `ld` path
       - name: meson wipe builddir for macOS re-link # macOS Homebrew installation prefix varies among runners, so wipe the builddir to force re-linking
         if: ${{ inputs.runner == 'macos-latest' }}
-        run: meson setup build-iguana --wipe
+        run: meson setup build-iguana iguana_src --wipe
       - name: meson configure
         run: |
           meson configure                           \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,12 +123,9 @@ jobs:
       image: ${{ inputs.container }}
     steps:
       - uses: cvmfs-contrib/github-action-cvmfs@v4
-        run: |
-          ls /cvmfs/sft.cern.ch
-          echo "==="
-          ls /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.28.10/x86_64-ubuntu22-gcc114-opt
-          echo "==="
-          ls /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.28.10/x86_64-mac127-clang140-opt
+      - run: ls /cvmfs/sft.cern.ch
+      - run: ls /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.28.10/x86_64-ubuntu22-gcc114-opt
+      - run: ls /cvmfs/sft.cern.ch/lcg/app/releases/ROOT/6.28.10/x86_64-mac127-clang140-opt
 
   # build
   #########################################################

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,16 +5,41 @@ on:
   push:
     branches: [ main ]
     tags: [ '*' ]
+  schedule:
+    - cron: '15 7 * * 0' # Sundays at 0715Z
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  WORKFLOW_ID: linux-latest
+
 jobs:
+
   linux:
     name: Linux (latest)
     uses: ./.github/workflows/ci.yml
     with:
-      id: linux-latest
+      id: ${{ env.WORKFLOW_ID }}
       runner: ubuntu-latest
       container: archlinux/archlinux:latest
+
+  issue_bot:
+    name: Issue bot
+    # if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
+    runs-on: ubuntu-latest
+    needs: [ linux ]
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_ID: ${{ env.WORKFLOW_ID }}
+          RUN_ID: ${{ github.run_id }}
+          REPO_URL: ${{ github.event.repository.html_url }}
+        with:
+          filename: .github/schedule-issue.md

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,16 +12,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  WORKFLOW_ID: linux-latest
-
 jobs:
 
   linux:
     name: Linux (latest)
     uses: ./.github/workflows/ci.yml
     with:
-      id: ${{ env.WORKFLOW_ID }}
+      id: linux-latest
       runner: ubuntu-latest
       container: archlinux/archlinux:latest
 
@@ -38,7 +35,7 @@ jobs:
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_ID: ${{ env.WORKFLOW_ID }}
+          WORKFLOW_ID: linux-latest
           RUN_ID: ${{ github.run_id }}
           REPO_URL: ${{ github.event.repository.html_url }}
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,21 +5,47 @@ on:
   push:
     branches: [ main ]
     tags: [ '*' ]
+  schedule:
+    - cron: '15 7 * * 0' # Sundays at 0715Z
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  WORKFLOW_ID: macOS
+
 jobs:
+
   macOS:
     name: macOS (latest)
     uses: ./.github/workflows/ci.yml
     with:
-      id: macOS
+      id: ${{ env.WORKFLOW_ID }}
       runner: macos-latest
       test_matrix: >-
         {
           "include": [
-            { "mode": "test", "CC": "gcc", "CXX": "g++", "buildtype": "release" }
+            { "mode": "test",   "build_id": "cpp-gcc-release",        "CC": "gcc", "CXX": "g++", "buildtype": "release" }
+            { "mode": "noROOT", "build_id": "cpp-gcc-release-noROOT", "CC": "gcc", "CXX": "g++", "buildtype": "release" }
           ]
         }
+
+  issue_bot:
+    name: Issue bot
+    # if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
+    runs-on: ubuntu-latest
+    needs: [ macOS ]
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_ID: ${{ env.WORKFLOW_ID }}
+          RUN_ID: ${{ github.run_id }}
+          REPO_URL: ${{ github.event.repository.html_url }}
+        with:
+          filename: .github/schedule-issue.md

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,16 +12,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  WORKFLOW_ID: macOS
-
 jobs:
 
   macOS:
     name: macOS (latest)
     uses: ./.github/workflows/ci.yml
     with:
-      id: ${{ env.WORKFLOW_ID }}
+      id: macOS
       runner: macos-latest
       test_matrix: >-
         {
@@ -44,7 +41,7 @@ jobs:
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_ID: ${{ env.WORKFLOW_ID }}
+          WORKFLOW_ID: macOS
           RUN_ID: ${{ github.run_id }}
           REPO_URL: ${{ github.event.repository.html_url }}
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
       test_matrix: >-
         {
           "include": [
-            { "mode": "test",   "build_id": "cpp-gcc-release",        "CC": "gcc", "CXX": "g++", "buildtype": "release" }
+            { "mode": "test",   "build_id": "cpp-gcc-release",        "CC": "gcc", "CXX": "g++", "buildtype": "release" },
             { "mode": "noROOT", "build_id": "cpp-gcc-release-noROOT", "CC": "gcc", "CXX": "g++", "buildtype": "release" }
           ]
         }

--- a/.github/workflows/minver.yml
+++ b/.github/workflows/minver.yml
@@ -21,7 +21,7 @@ jobs:
       test_matrix: >-
         {
           "include": [
-            { "mode": "test",   "build_id": "cpp-gcc-release",        "CC": "gcc", "CXX": "g++", "buildtype": "release" }
+            { "mode": "test",   "build_id": "cpp-gcc-release",        "CC": "gcc", "CXX": "g++", "buildtype": "release" },
             { "mode": "noROOT", "build_id": "cpp-gcc-release-noROOT", "CC": "gcc", "CXX": "g++", "buildtype": "release" }
           ]
         }

--- a/.github/workflows/minver.yml
+++ b/.github/workflows/minver.yml
@@ -1,27 +1,49 @@
 name: MinVer # minimum required-version of dependencies on Linux
 
 on:
-  pull_request:
-  push:
-    branches: [ main ]
-    tags: [ '*' ]
+  schedule:
+    - cron: '15 7 * * 0' # Sundays at 0715Z
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  WORKFLOW_ID: linux-minver
+
 jobs:
-  Linux:
+
+  linux:
     name: Linux (minver)
     uses: ./.github/workflows/ci.yml
     with:
-      id: linux-minver
+      id: ${{ env.WORKFLOW_ID }}
       runner: ubuntu-latest
       container: archlinux/archlinux:latest
       verset: minver
       test_matrix: >-
         {
           "include": [
-            { "mode": "test", "CC": "gcc", "CXX": "g++", "buildtype": "release" }
+            { "mode": "test",   "build_id": "cpp-gcc-release",        "CC": "gcc", "CXX": "g++", "buildtype": "release" }
+            { "mode": "noROOT", "build_id": "cpp-gcc-release-noROOT", "CC": "gcc", "CXX": "g++", "buildtype": "release" }
           ]
         }
+
+  issue_bot:
+    name: Issue bot
+    # if: ${{ github.event_name == 'schedule' && ( cancelled() || failure() ) }}
+    runs-on: ubuntu-latest
+    needs: [ linux ]
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_ID: ${{ env.WORKFLOW_ID }}
+          RUN_ID: ${{ github.run_id }}
+          REPO_URL: ${{ github.event.repository.html_url }}
+        with:
+          filename: .github/schedule-issue.md

--- a/.github/workflows/minver.yml
+++ b/.github/workflows/minver.yml
@@ -8,16 +8,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-env:
-  WORKFLOW_ID: linux-minver
-
 jobs:
 
   linux:
     name: Linux (minver)
     uses: ./.github/workflows/ci.yml
     with:
-      id: ${{ env.WORKFLOW_ID }}
+      id: linux-minver
       runner: ubuntu-latest
       container: archlinux/archlinux:latest
       verset: minver
@@ -42,7 +39,7 @@ jobs:
       - uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_ID: ${{ env.WORKFLOW_ID }}
+          WORKFLOW_ID: linux-minver
           RUN_ID: ${{ github.run_id }}
           REPO_URL: ${{ github.event.repository.html_url }}
         with:

--- a/bind/python/README.md
+++ b/bind/python/README.md
@@ -29,6 +29,10 @@ For Python to be able to find and use these bindings, you need to set some envir
 > - on Linux: `source iguana/bin/this_iguana.sh`
 > - on macOS: `source iguana/bin/this_iguana.sh ld` (where `ld` is needed to set `DYLD_LIBRARY_PATH`)
 
+> [!IMPORTANT]
+> If you have ROOT, you likely already have `cppyy` as part of its installation. Be sure that `$PYTHONPATH`
+> prioritizes ROOT's installation, so the "correct" `cppyy` is used
+
 ## Running the Examples
 
 Example Python scripts are found in this directory as `iguana-example-*.py`; they will be installed in the `bin/` subdirectory.

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -24,6 +24,7 @@ Keep the Python binding dependency versions reasonably up to date in the corresp
 We currently support up to the C++ standard defined in:
 - [`meson.build`](/meson.build)
 - example build configurations in [`examples/build_with_*` subdirectories](/examples)
+- in the [main CI workflow](/.github/workflows/ci.yml), the standard used for the ROOT build (`CMAKE_CXX_STANDARD`)
 
 ## Code Ownership
 

--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -21,10 +21,10 @@ Keep the Python binding dependency versions reasonably up to date in the corresp
 
 ## C++ Standard
 
-We currently support up to the C++ standard defined in:
-- [`meson.build`](/meson.build)
-- example build configurations in [`examples/build_with_*` subdirectories](/examples)
-- in the [main CI workflow](/.github/workflows/ci.yml), the standard used for the ROOT build (`CMAKE_CXX_STANDARD`)
+We currently support up to the C++ standard defined in [`meson.build`](/meson.build); if you change this, you will also need to update:
+- [ ] example build configurations in [`examples/build_with_*` subdirectories](/examples)
+- [ ] in the [main CI workflow](/.github/workflows/ci.yml), the standard used for the ROOT build (`CMAKE_CXX_STANDARD`)
+- [ ] any mention of the standard in documentation
 
 ## Code Ownership
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -12,7 +12,7 @@
 The following sections (🔶) list the dependencies and how to obtain them.
 
 > [!TIP]
-> It's generally better to use your a package manager to install dependencies, _e.g._:
+> It's generally better to use your a package manager to install most dependencies, _e.g._:
 > - macOS Homebrew: `brew install <package>`
 > - Linux (depends on distribution) examples: `apt install <package>`, `dnf install <package>`, `pacman -S <package>`
 > - The name of the package may be different for different package managers; search for and read about the package before installing it
@@ -51,6 +51,17 @@ cmake -S /path/to/hipo_source_code -B build-hipo -DCMAKE_INSTALL_PREFIX=/path/to
 cmake --build build-hipo
 cmake --install build-hipo
 ```
+
+### 🔶 Optional: `ROOT`: Data analysis framework
+<https://root.cern.ch/>
+- ROOT is an **optional** dependency: some algorithms and test code depends on ROOT, but if you do not
+  have ROOT on your system, `iguana` will build everything _except_ ROOT-dependent code
+- It is **NOT recommended** to use your package manager to install ROOT; the most reliable installation
+  method is [building it from source](https://root.cern/install/build_from_source/)
+  - You may need to set the C++ standard to match that used in `iguana`, which is currently 17; to do so,
+    use the build option `-DCMAKE_CXX_STANDARD=17`
+  - Depending on ROOT's installation prefix, you may also need to set your environment so ROOT may be found;
+    this is typically done by `source /path/to/root/bin/thisroot.sh`
 
 <a name="building"></a>
 ## 🟠 Building and Installing

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -60,8 +60,8 @@ cmake --install build-hipo
   method is [building it from source](https://root.cern/install/build_from_source/)
   - You may need to set the C++ standard to match that used in `iguana`, which is currently 17; to do so,
     use the build option `-DCMAKE_CXX_STANDARD=17`
-  - Depending on ROOT's installation prefix, you may also need to set your environment so ROOT may be found;
-    this is typically done by `source /path/to/root/bin/thisroot.sh`
+- After installation, depending on ROOT's installation prefix you may also need to set your environment so
+  ROOT may be found; this is typically done by `source /path/to/root/bin/thisroot.sh`
 
 <a name="building"></a>
 ## 🟠 Building and Installing

--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,7 @@ hipo_dep = dependency(
 )
 ROOT_dep = dependency(
   'ROOT',
-  required: false,
+  required: get_option('require_ROOT'),
   method:   'cmake',
   version: run_command('meson' / 'minimum-version.sh', 'ROOT', check: true).stdout().strip()
 )

--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,7 @@ ROOT_dep = dependency(
   'ROOT',
   required: false,
   method:   'cmake',
-  version:  '>=6.28'
+  version: run_command('meson' / 'minimum-version.sh', 'ROOT', check: true).stdout().strip()
 )
 
 # list of dependencies

--- a/meson.options
+++ b/meson.options
@@ -2,5 +2,5 @@ option('examples',        type: 'boolean', value: false, description: 'Build Igu
 option('documentation',   type: 'boolean', value: false, description: 'Generate API documentation (requires Doxygen)')
 option('test_data_file',  type: 'string',  value: '',    description: 'Sample HIPO file for testing. Must be an absolute path or relative to the build directory. If unspecified, tests are not built')
 option('test_num_events', type: 'string',  value: '10',  description: 'Number of events from `test_data_file` to test')
-option('require_ROOT',    type: 'boolean', value: false, description: 'If false, ROOT is only used if it is found; if true, ROOT is REQUIRED and the build will fail of ROOT is not found')
+option('require_ROOT',    type: 'boolean', value: false, description: 'If false, ROOT is only used if it is found; if true, ROOT is REQUIRED and the build will fail if ROOT is not found')
 option('bind_python',     type: 'boolean', value: false, description: 'Generate Python bindings and their examples')

--- a/meson.options
+++ b/meson.options
@@ -2,4 +2,5 @@ option('examples',        type: 'boolean', value: false, description: 'Build Igu
 option('documentation',   type: 'boolean', value: false, description: 'Generate API documentation (requires Doxygen)')
 option('test_data_file',  type: 'string',  value: '',    description: 'Sample HIPO file for testing. Must be an absolute path or relative to the build directory. If unspecified, tests are not built')
 option('test_num_events', type: 'string',  value: '10',  description: 'Number of events from `test_data_file` to test')
+option('require_ROOT',    type: 'boolean', value: false, description: 'If false, ROOT is only used if it is found; if true, ROOT is REQUIRED and the build will fail of ROOT is not found')
 option('bind_python',     type: 'boolean', value: false, description: 'Generate Python bindings and their examples')

--- a/meson/minimum-version.sh
+++ b/meson/minimum-version.sh
@@ -10,6 +10,8 @@ if [ $# -eq 0 ]; then
 
             ALA     return a URL for the Arch Linux Archive (ALA), for CI
                     https://archive.archlinux.org/
+
+            src     return a URL of the source code
   """
   exit 2
 fi
@@ -22,10 +24,17 @@ case $dep in
   fmt)
     result_meson='>=9.1.0'
     result_ala='https://archive.archlinux.org/packages/f/fmt/fmt-9.1.0-4-x86_64.pkg.tar.zst'
+    [ "$cmd" = "src" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1
     ;;
   yaml-cpp)
     result_meson='>=0.7.0'
     result_ala='https://archive.archlinux.org/packages/y/yaml-cpp/yaml-cpp-0.7.0-2-x86_64.pkg.tar.zst'
+    [ "$cmd" = "src" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1
+    ;;
+  root|ROOT)
+    result_meson='>=6.28'
+    [ "$cmd" = "ALA" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1
+    result_src='https://root.cern/download/root_v6.28.12.source.tar.gz'
     ;;
   *)
     echo "ERROR: dependency '$dep' is unknown" >&2
@@ -38,6 +47,7 @@ esac
 case $cmd in
   meson) echo $result_meson ;;
   ALA)   echo $result_ala   ;;
+  src)   echo $result_src   ;;
   *)
     echo "ERROR: command '$cmd' is unknown" >&2
     exit 1

--- a/meson/resolve-dependencies.py
+++ b/meson/resolve-dependencies.py
@@ -21,6 +21,7 @@ parser_deps = parser.add_argument_group('dependency installation paths')
 parser_deps.add_argument('--hipo', default=SYSTEM_ASSUMPTION, type=str, help='path to `hipo` installation')
 parser_deps.add_argument('--fmt', default=SYSTEM_ASSUMPTION, type=str, help='path to `fmt` installation')
 parser_deps.add_argument('--yaml', default=SYSTEM_ASSUMPTION, type=str, help='path to `yaml-cpp` installation')
+parser_deps.add_argument('--root', default=SYSTEM_ASSUMPTION, type=str, help='path to `ROOT` installation')
 parser_output = parser.add_argument_group('output control')
 parser_output.add_argument('--cli', default=False, action=argparse.BooleanOptionalAction, help='only print the `meson` CLI options, and nothing else')
 parser_output.add_argument('--ini', default=NOT_USED, type=str, help='if set, generate an INI file (meson native file) with this name; you may then use it with `meson setup --native-file=_____`')
@@ -51,7 +52,7 @@ def use_pkg_config(dep, pc_file, arg):
         pkg_config_path.add(pc_path)
     else:
         use_system(dep)
-def use_cmake(dep, path):
+def use_cmake(dep, arg):
     if(arg != SYSTEM_ASSUMPTION):
         path = os.path.realpath(arg)
         print_verbose(f'{dep}: using cmake files from {path}')
@@ -63,6 +64,7 @@ def use_cmake(dep, path):
 use_pkg_config('hipo', 'hipo4.pc',    args.hipo)
 use_pkg_config('fmt',  'fmt.pc',      args.fmt)
 use_pkg_config('yaml', 'yaml-cpp.pc', args.yaml)
+use_cmake('ROOT', args.root)
 ################################################
 
 

--- a/src/iguana/algorithms/Algorithm.cc
+++ b/src/iguana/algorithms/Algorithm.cc
@@ -12,34 +12,6 @@ namespace iguana {
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  OPTION_TYPE Algorithm::SetOption(const std::string key, const OPTION_TYPE val)
-  {
-    if(key == "log") {
-      if constexpr(std::disjunction<
-                       std::is_same<OPTION_TYPE, std::string>,
-                       std::is_same<OPTION_TYPE, const char*>,
-                       std::is_same<OPTION_TYPE, Logger::Level>>::value)
-        m_log->SetLevel(val);
-      else
-        m_log->Error("Option '{}' must be a string or a Logger::Level", key);
-    }
-    else {
-      m_option_cache[key] = val;
-      m_log->Debug("  USER OPTION: {:>20} = {}", key, PrintOptionValue(key));
-    }
-    return val;
-  }
-  template int Algorithm::SetOption(const std::string key, const int val);
-  template double Algorithm::SetOption(const std::string key, const double val);
-  template std::string Algorithm::SetOption(const std::string key, const std::string val);
-  template const char* Algorithm::SetOption(const std::string key, const char* val);
-  template std::vector<int> Algorithm::SetOption(const std::string key, const std::vector<int> val);
-  template std::vector<double> Algorithm::SetOption(const std::string key, const std::vector<double> val);
-  template std::vector<std::string> Algorithm::SetOption(const std::string key, const std::vector<std::string> val);
-
-  ///////////////////////////////////////////////////////////////////////////////
-
-  template <typename OPTION_TYPE>
   OPTION_TYPE Algorithm::GetOptionScalar(const std::string key, YAMLReader::node_path_t node_path)
   {
     try {

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -76,7 +76,24 @@ namespace iguana {
       /// @param val the value to set
       /// @returns the value that has been set (if needed, _e.g._, when `val` is an rvalue)
       template <typename OPTION_TYPE>
-      OPTION_TYPE SetOption(const std::string key, const OPTION_TYPE val);
+      OPTION_TYPE SetOption(const std::string key, const OPTION_TYPE val)
+      {
+        // FIXME: this template is not specialized, to be friendlier to python `cppyy` bindings
+        if(key == "log") {
+          if constexpr(std::disjunction<
+                           std::is_same<OPTION_TYPE, std::string>,
+                           std::is_same<OPTION_TYPE, const char*>,
+                           std::is_same<OPTION_TYPE, Logger::Level>>::value)
+            m_log->SetLevel(val);
+          else
+            m_log->Error("Option '{}' must be a string or a Logger::Level", key);
+        }
+        else {
+          m_option_cache[key] = val;
+          m_log->Debug("  USER OPTION: {:>20} = {}", key, PrintOptionValue(key));
+        }
+        return val;
+      }
 
       /// Get the value of a scalar option
       /// @param key the unique key name of this option, for caching; if empty, the option will not be cached

--- a/src/iguana/tests/meson.build
+++ b/src/iguana/tests/meson.build
@@ -7,6 +7,7 @@ test_exe = executable(
   include_directories: [ test_exe_inc, project_inc ],
   dependencies:        project_deps,
   link_with:           project_libs,
+  link_args:           ROOT_dep_link_args,
   install:             false,
   install_rpath:       ':'.join(project_exe_rpath),
 )


### PR DESCRIPTION
- build and cache ROOT from source, since installing ROOT from `Homebrew` or `pacman` returns a package that `meson` cannot "find"; this gives us more control over the ROOT build anyway, in case someone needs non-default options
- rebuild HIPO and ROOT weekly on early Sunday mornings, so that the cached builds are up-to-date with respect to upstream
- drop `MinVer` workflow trigger on PRs, and leave it to the weekly runs; we don't need to check this one so often
- add `noROOT` build tests, to test for users who do not have ROOT