### PR TITLE
Sectors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,4 +9,5 @@
 * @c-dilks
 src/iguana/algorithms/clas12/MomentumCorrection.* @RichCap @c-dilks
 src/iguana/algorithms/clas12/ZVertexFilter.* @rtysonCLAS12
+src/iguana/algorithms/clas12/SectorFinder.* @rtysonCLAS12
 src/iguana/services/YAMLReader.* @rtysonCLAS12 @c-dilks

--- a/src/iguana/algorithms/clas12/SectorFinder.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder.cc
@@ -14,16 +14,13 @@ namespace iguana::clas12 {
     // get expected bank indices
     b_particle = GetBankIndex(banks, "REC::Particle");
     if(o_bankname!="default"){
-        b_nondefault=GetBankIndex(banks, o_bankname);
-        b_calorimeter=0;
-        b_track=0;
-        b_scint=0;
-
+        b_user=GetBankIndex(banks, o_bankname);
+        userSpecifiedBank=true;
     } else{
         b_calorimeter=GetBankIndex(banks, "REC::Calorimeter");
         b_track=GetBankIndex(banks, "REC::Track");
         b_scint=GetBankIndex(banks, "REC::Scintillator");
-        b_nondefault=0;
+        userSpecifiedBank=false;
     }
   }
 
@@ -48,17 +45,17 @@ namespace iguana::clas12 {
     std::vector<int> sectors;
     // get the banks
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
-    auto& nondefaultBank=GetBank(banks, b_nondefault);
+    auto& userBank=GetBank(banks, b_user);
     auto& calBank=GetBank(banks, b_calorimeter);
     auto& scintBank=GetBank(banks,b_scint);
     auto& trackBank=GetBank(banks,b_track);
 
     // filter the input bank for requested PDG code(s)
     for(int row = 0; row < particleBank.getRows(); row++) {
-      if(o_bankname!="default"){
-        //if user specified a secific bank
-        if(nondefaultBank.getRows()>0){
-          sectors.push_back(getSector(nondefaultBank,row));
+      if(userSpecifiedBank){
+        //if user specified a specific bank
+        if(userBank.getRows()>0){
+          sectors.push_back(getSector(userBank,row));
         } else{
           //bank may be empty
           sectors.push_back(0);
@@ -73,7 +70,7 @@ namespace iguana::clas12 {
           if(scintBank.getRows()>0){
             scintSector=getSector(scintBank,row);
           }
-          
+
           int calSector=0;
           if(calBank.getRows()>0){
             calSector=getSector(calBank,row);

--- a/src/iguana/algorithms/clas12/SectorFinder.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder.cc
@@ -1,0 +1,89 @@
+#include "SectorFinder.h"
+
+namespace iguana::clas12 {
+
+  REGISTER_IGUANA_ALGORITHM(SectorFinder);
+
+  void SectorFinder::Start(hipo::banklist& banks)
+  {
+
+    // define options, their default values, and cache them
+    ParseYAMLConfig();
+    o_bankname = GetOptionScalar<std::string>("bank");
+
+    // get expected bank indices
+    b_particle = GetBankIndex(banks, "REC::Particle");
+    if(o_bankname!="default"){
+        b_nondefault=GetBankIndex(banks, o_bankname);
+        b_calorimeter=0;
+        b_track=0;
+        b_scint=0;
+
+    } else{
+        b_calorimeter=GetBankIndex(banks, "REC::Calorimeter");
+        b_track=GetBankIndex(banks, "REC::Track");
+        b_scint=GetBankIndex(banks, "REC::Scintillator");
+        b_nondefault=0;
+    }
+  }
+
+
+  //explicitly leave empty, run does nothing
+  void SectorFinder::Run(hipo::banklist& banks) const
+  {
+  }
+
+  int SectorFinder::getSector(hipo::bank &bank, int pindex) const {
+    int sector=0;
+    for(int row = 0; row < bank.getRows(); row++) {
+      if(bank.getInt("pindex",row)==pindex){
+        return bank.getInt("sector",row);
+      }
+    }
+    return sector;
+  }
+
+  std::vector<int> SectorFinder::Find(hipo::banklist& banks) const
+  {
+    std::vector<int> sectors;
+    // get the banks
+    auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
+    auto& nondefaultBank=GetBank(banks, b_nondefault);
+    auto& calBank=GetBank(banks, b_calorimeter);
+    auto& scintBank=GetBank(banks,b_scint);
+    auto& trackBank=GetBank(banks,b_track);
+
+    // filter the input bank for requested PDG code(s)
+    for(int row = 0; row < particleBank.getRows(); row++) {
+      if(o_bankname!="default"){
+        //if user specified a secific bank
+        if(nondefaultBank.getRows()>0){
+          sectors.push_back(getSector(nondefaultBank,row));
+        } else{
+          //bank may be empty
+          sectors.push_back(0);
+        } 
+      } else{
+          if(trackBank.getRows()>0){
+            sectors.push_back(getSector(trackBank,row));
+          } else if(scintBank.getRows()>0){
+            sectors.push_back(getSector(scintBank,row));
+          } else if(calBank.getRows()>0){
+            sectors.push_back(getSector(calBank,row));
+          } else{
+            //banks may be empty
+            sectors.push_back(0);
+          }
+          
+        }
+    }
+
+    return sectors;
+  }
+
+
+  void SectorFinder::Stop()
+  {
+  }
+
+}

--- a/src/iguana/algorithms/clas12/SectorFinder.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder.cc
@@ -64,16 +64,32 @@ namespace iguana::clas12 {
           sectors.push_back(0);
         } 
       } else{
+          int trackSector=0;
           if(trackBank.getRows()>0){
-            sectors.push_back(getSector(trackBank,row));
-          } else if(scintBank.getRows()>0){
-            sectors.push_back(getSector(scintBank,row));
-          } else if(calBank.getRows()>0){
-            sectors.push_back(getSector(calBank,row));
-          } else{
-            //banks may be empty
-            sectors.push_back(0);
+            trackSector=getSector(trackBank,row);
+          } 
+          
+          int scintSector=0;
+          if(scintBank.getRows()>0){
+            scintSector=getSector(scintBank,row);
           }
+          
+          int calSector=0;
+          if(calBank.getRows()>0){
+            calSector=getSector(calBank,row);
+          } 
+          
+          if(trackSector!=0){
+            sectors.push_back(trackSector);
+          } else if(scintSector!=0){
+            sectors.push_back(scintSector);
+          } else{
+            //add even if calSector is 0
+            //need an entry per pindex
+            //can happen that particle not in FD
+            //ie sector is 0
+            sectors.push_back(calSector);
+          } 
           
         }
     }

--- a/src/iguana/algorithms/clas12/SectorFinder.h
+++ b/src/iguana/algorithms/clas12/SectorFinder.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "iguana/algorithms/Algorithm.h"
+
+namespace iguana::clas12 {
+
+  /// @brief Find the sector for all rows in REC::Particle
+  class SectorFinder : public Algorithm
+  {
+
+      DEFINE_IGUANA_ALGORITHM(SectorFinder, clas12::SectorFinder)
+
+    public:
+
+      void Start(hipo::banklist& banks) override;
+      void Run(hipo::banklist& banks) const override;
+      void Stop() override;
+
+      /// **Action function**: finds the sector for all rows in REC::Particle
+      /// @param banks the list of banks to process
+      /// @returns std::vector of sector numbers
+      std::vector<int> Find(hipo::banklist& banks) const;
+
+      /// get sector from bank for a given pindex
+      /// @param bank bank to get sector from
+      /// @param pindex index in bank for which to get sector
+      /// @returns sector for pindex in bank
+      int getSector(hipo::bank &bank, int pindex) const;
+
+    private:
+
+      /// `hipo::banklist` index for the particle bank
+      hipo::banklist::size_type b_particle;
+      hipo::banklist::size_type b_calorimeter;
+      hipo::banklist::size_type b_track;
+      hipo::banklist::size_type b_scint;
+      hipo::banklist::size_type b_nondefault;
+
+      /// Configuration options
+      std::string o_bankname;
+  };
+
+}

--- a/src/iguana/algorithms/clas12/SectorFinder.h
+++ b/src/iguana/algorithms/clas12/SectorFinder.h
@@ -34,7 +34,8 @@ namespace iguana::clas12 {
       hipo::banklist::size_type b_calorimeter;
       hipo::banklist::size_type b_track;
       hipo::banklist::size_type b_scint;
-      hipo::banklist::size_type b_nondefault;
+      hipo::banklist::size_type b_user;
+      bool userSpecifiedBank{false};
 
       /// Configuration options
       std::string o_bankname;

--- a/src/iguana/algorithms/clas12/SectorFinder.yaml
+++ b/src/iguana/algorithms/clas12/SectorFinder.yaml
@@ -1,0 +1,6 @@
+clas12::SectorFinder:
+  # list of PDG codes to filter for
+  bank: default
+
+  #can force finder to use a certain bank with eg:
+  #bank: REC::Calorimeter

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -37,7 +37,7 @@ algo_dict = {
     'sources':      [ 'clas12/SectorFinder.cc' ],
     'headers':      [ 'clas12/SectorFinder.h' ],
     'configs':      [ 'clas12/SectorFinder.yaml' ],
-    'unit_test':    { 'banks': ['REC::Particle','REC::Calorimeter','REC::Track','REC::SCintillator','REC::Cherenkov'] },
+    'unit_test':    { 'banks': ['REC::Particle','REC::Calorimeter','REC::Track','REC::Scintillator','REC::Cherenkov'] },
   },
   'clas12::LorentzTransformer': {
     'sources':      [ 'clas12/LorentzTransformer.cc' ],

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -33,6 +33,12 @@ algo_dict = {
     'configs':      [ 'clas12/ZVertexFilter.yaml' ],
     'unit_test':    { 'banks': ['REC::Particle'] },
   },
+  'clas12::SectorFinder': {
+    'sources':      [ 'clas12/SectorFinder.cc' ],
+    'headers':      [ 'clas12/SectorFinder.h' ],
+    'configs':      [ 'clas12/SectorFinder.yaml' ],
+    'unit_test':    { 'banks': ['REC::Particle','REC::Calorimeter','REC::Track','REC::SCintillator','REC::Cherenkov'] },
+  },
   'clas12::LorentzTransformer': {
     'sources':      [ 'clas12/LorentzTransformer.cc' ],
     'headers':      [ 'clas12/LorentzTransformer.h' ],


### PR DESCRIPTION
Added code to find sectors. Logic is following:

 - either the user specifies a bank in a config file, in which case sector is found from there
 - otherwise, sector will be found first from REC::Track if non empty, then from REC::Scintillator if non empty, then from REC::Calorimeter, defaults to 0 if all banks empty. 

Second option mimics clas12root sector finding. Users developing algorithms with clas12root might not be aware of how the sectors are found so use the same default logic to reproduce their algorithms. Sector finding is more explicit in Java and so users can use first option to reproduce their algorithms

Sectors are found for each entry in the REC::Particle bank, ie sectors are found per pindex. If none of banks used contain an entry for a given pindex, the sector is assigned 0. This can happen if a particle is detected in the CD or FT and not the FT.