### PR TITLE
build: revert static `hipo` link

### DIFF
--- a/examples/build_with_meson/meson.build
+++ b/examples/build_with_meson/meson.build
@@ -7,7 +7,7 @@ project(
 
 # find dependencies
 # - it's good practice to specifiy minimum version requirements; here we just assume that `iguana` already did this
-hipo_dep   = dependency('hipo4', static: true) # use static link, for performance
+hipo_dep   = dependency('hipo4')
 iguana_dep = dependency('iguana')
 
 # set rpath
@@ -15,8 +15,11 @@ iguana_dep = dependency('iguana')
 # - alternatively, set $LD_LIBRARY_PATH before running your executables ($DYLD_LIBRARY_PATH on macOS)
 # - not needed for libraries which are static-linked
 bin_rpaths = [
-  iguana_dep.get_variable(pkgconfig: 'libdir')
+  hipo_dep.get_variable(pkgconfig: 'libdir')
 ]
+if host_machine.system() != 'darwin'
+  bin_rpaths += iguana_dep.get_variable(pkgconfig: 'libdir') # not needed on macOS
+endif
 
 # build and install the executable
 example_bin = 'iguana-example-00-basic'

--- a/meson.build
+++ b/meson.build
@@ -147,7 +147,9 @@ project_test_env.set(
 )
 
 # executables' rpath
-project_exe_rpath = []
+project_exe_rpath = [
+  hipo_dep.get_variable(pkgconfig: 'libdir')
+]
 if host_machine.system() != 'darwin'
   # FIXME(darwin): not sure how to set multiple rpaths on darwin executables,
   # aside from running `install_name_tool -add_rpath` post-installation;

--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,6 @@ yamlcpp_dep = dependency(
 )
 hipo_dep = dependency(
   'hipo4',
-  static:  true,
   method:  'pkg-config',
   version: '>=4.0.1',
 )


### PR DESCRIPTION
revert https://github.com/JeffersonLab/iguana/pull/74

fix: #111

Users may use `prefer_static` build option to control linking behavior.