### PR TITLE
build: add native file for `ifarm` builds

### DIFF
--- a/meson/ifarm/README.md
+++ b/meson/ifarm/README.md
@@ -1,0 +1,25 @@
+# Building for `ifarm` or `cvmfs`
+
+## Resolve dependencies
+
+Follow [the dependency resolution guide](/doc/dependency_resolution.md) or run the dependency resolution script
+```bash
+meson/resolve-dependencies.py --help  # prints the usage guide
+```
+
+> [!TIP]
+> Use `--ini` to generate an INI file, which may be combined with the INI file from the next step
+
+## Build
+
+Replace anything in `<angle brackets>` with the appropriate string; you may run these commands from any directory,
+preferably outside the source tree. The set of preferred options for `ifarm` builds is contained in [`ifarm.ini`](ifarm.ini), which may be passed to `meson` as a "native file".
+
+```bash
+meson setup <build_directory> <source_directory> <build_options_from_resolve_dependencies> --native-file=<source_directory>/ifarm/ifarm.ini
+meson configure <build_directory> --prefix=<absolute_path_to_installation_destination>
+meson install -C <build_directory>
+```
+
+> [!TIP]
+> You may also add your prefix to the INI file, instead of calling `meson configure --prefix`

--- a/meson/ifarm/ifarm.ini
+++ b/meson/ifarm/ifarm.ini
@@ -1,0 +1,9 @@
+; options set for ifarm or cvmfs builds
+[built-in options]
+; core
+buildtype = 'release'
+; project options
+examples = True
+documentation = False
+require_ROOT = True
+bind_python = True


### PR DESCRIPTION
@baltzell this adds the directory `meson/ifarm` with concise build directions and a native INI file with recommended build options. You're welcome to modify these as needed.