### PR TITLE
test: meson 1.4.0 respecting sanitizer options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ defaults:
 env:
   hipo_version: f40da676bbd1745398e9fdf233ff213ff98798f1
   num_events: 1000
+  ASAN_OPTIONS: 'bad_option'
+  UBSAN_OPTIONS: 'bad_option'
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ defaults:
 env:
   hipo_version: f40da676bbd1745398e9fdf233ff213ff98798f1
   num_events: 1000
-  ASAN_OPTIONS: 'bad_option'
-  UBSAN_OPTIONS: 'bad_option'
+  ASAN_OPTIONS: 'suppressions=non_existent_file.supp'
+  UBSAN_OPTIONS: 'suppressions=non_existent_file.supp'
 
 jobs:
 

--- a/meson.build
+++ b/meson.build
@@ -128,20 +128,20 @@ project_pkg_vars  = [
 ]
 
 # sanitizer settings
-project_test_env.set(
-  'UBSAN_OPTIONS',
-  'halt_on_error=1',
-  'abort_on_error=1',
-  'print_summary=1',
-  'print_stacktrace=1',
-  'suppressions=' + meson.project_source_root() / 'meson' / 'ubsan.supp',
-)
-project_test_env.set(
-  'ASAN_OPTIONS',
-  'halt_on_error=1',
-  'abort_on_error=1',
-  'print_summary=1',
-)
+# project_test_env.set(
+#   'UBSAN_OPTIONS',
+#   'halt_on_error=1',
+#   'abort_on_error=1',
+#   'print_summary=1',
+#   'print_stacktrace=1',
+#   'suppressions=' + meson.project_source_root() / 'meson' / 'ubsan.supp',
+# )
+# project_test_env.set(
+#   'ASAN_OPTIONS',
+#   'halt_on_error=1',
+#   'abort_on_error=1',
+#   'print_summary=1',
+# )
 project_test_env.set(
   'LSAN_OPTIONS',
   'suppressions=' + meson.project_source_root() / 'meson' / 'lsan.supp',


### PR DESCRIPTION
### do not merge

Meson 1.4 does not seem to be respecting UBSAN and ASAN options when set in `meson.build`. This PR tests behavior, to see if we can better understand the issue.