### PR TITLE
fix: add executable permission for group and other for Python examples

### DIFF
--- a/bind/python/meson.build
+++ b/bind/python/meson.build
@@ -14,6 +14,6 @@ foreach example : python_examples
   install_data(
     example,
     install_dir:  get_option('bindir'),
-    install_mode: 'rwxr--r--',
+    install_mode: 'rwxr-xr-x',
   )
 endforeach


### PR DESCRIPTION
close #137 