### PR TITLE
feat: tell the user which algorithm(s) create new banks

### DIFF
--- a/src/iguana/algorithms/Algorithm.cc
+++ b/src/iguana/algorithms/Algorithm.cc
@@ -228,6 +228,10 @@ namespace iguana {
       int group_id,
       int item_id) const
   {
+    if(!AlgorithmFactory::QueryNewBank(bank_name)) {
+      m_log->Error("{:?} creates bank {:?}, which is not registered; new banks must be included in `REGISTER_IGUANA_ALGORITHM` arguments", m_class_name, bank_name);
+      throw std::runtime_error("CreateBank failed");
+    }
     if(schema_def.empty()) {
       m_log->Error("empty schema_def in CreateBank");
       throw std::runtime_error("CreateBank failed");
@@ -241,8 +245,6 @@ namespace iguana {
         { return a + "," + b; }));
     banks.push_back({bank_schema});
     bank_idx = GetBankIndex(banks, bank_name);
-    if(!AlgorithmFactory::QueryNewBank(bank_name))
-      m_log->Error("'{}' is not registered as a creator algorithm; `REGISTER_IGUANA_NEW_BANKS` must be called in the algorithm source code", m_class_name);
     return bank_schema;
   }
 

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -254,7 +254,7 @@ namespace iguana {
       /// @param creator the creator function
       /// @param new_banks if this algorithm creates *new* banks, list them here
       /// @returns true if the algorithm has not yet been registered
-      static bool Register(const std::string& name, algo_creator_t creator, const std::vector<std::string>& new_banks) noexcept;
+      static bool Register(const std::string& name, algo_creator_t creator, const std::vector<std::string> new_banks={}) noexcept;
 
       /// Create an algorithm. Throws an exception if the algorithm cannot be created
       /// @param name the name of the algorithm, which was used as an argument in the `AlgorithmFactory::Register` call

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -143,9 +143,9 @@ namespace iguana {
 
       /// Get the index of a bank in a `hipo::banklist`; throws an exception if the bank is not found
       /// @param banks the list of banks this algorithm will use
-      /// @param bankName the name of the bank
+      /// @param bank_name the name of the bank
       /// returns the `hipo::banklist` index of the bank
-      hipo::banklist::size_type GetBankIndex(hipo::banklist& banks, const std::string bankName) const noexcept(false);
+      hipo::banklist::size_type GetBankIndex(hipo::banklist& banks, const std::string bank_name) const noexcept(false);
 
       /// Return a string with the value of an option along with its type
       /// @param key the name of the option
@@ -155,9 +155,9 @@ namespace iguana {
       /// Get the reference to a bank from a `hipo::banklist`; optionally checks if the bank name matches the expectation
       /// @param banks the `hipo::banklist` from which to get the specified bank
       /// @param idx the index of `banks` of the specified bank
-      /// @param expectedBankName if specified, checks that the specified bank has this name
+      /// @param expected_bank_name if specified, checks that the specified bank has this name
       /// @return a reference to the bank
-      hipo::bank& GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, const std::string expectedBankName = "") const noexcept(false);
+      hipo::bank& GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, const std::string expected_bank_name = "") const noexcept(false);
 
       /// Mask a row, setting all items to zero
       /// @param bank the bank to modify
@@ -252,15 +252,31 @@ namespace iguana {
       /// Register an algorithm with a unique name. Algorithms register themselves by calling this function.
       /// @param name the name of the algorithm (not equivalent to `Object::m_name`)
       /// @param creator the creator function
+      /// @returns true if the algorithm has not yet been registered
       static bool Register(const std::string& name, algo_creator_t creator) noexcept;
 
       /// Create an algorithm. Throws an exception if the algorithm cannot be created
       /// @param name the name of the algorithm, which was used as an argument in the `AlgorithmFactory::Register` call
+      /// @returns the algorithm instance
       static algo_t Create(const std::string& name) noexcept(false);
+
+      /// Register banks that are created by a creator-type algorithm
+      /// @param bank_names the list of new bank names
+      /// @param algo_name the name of the algorithm which creates the new banks
+      /// @returns true if successful
+      static bool RegisterNewBanks(const std::vector<std::string>& bank_names, const std::string& algo_name) noexcept;
+
+      /// Check if a bank is created by an algorithm
+      /// @param bank_name the name of the bank
+      /// @returns the list of algorithms which create it, if any
+      static std::optional<std::vector<std::string>> QueryNewBank(const std::string& bank_name) noexcept;
 
     private:
 
       /// Association between the algorithm names and their creators
       static std::unordered_map<std::string, algo_creator_t> s_creators;
+
+      /// Association between a created bank and its creator algorithms
+      static std::unordered_map<std::string, std::vector<std::string>> s_created_banks;
   };
 }

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -252,19 +252,14 @@ namespace iguana {
       /// Register an algorithm with a unique name. Algorithms register themselves by calling this function.
       /// @param name the name of the algorithm (not equivalent to `Object::m_name`)
       /// @param creator the creator function
+      /// @param new_banks if this algorithm creates *new* banks, list them here
       /// @returns true if the algorithm has not yet been registered
-      static bool Register(const std::string& name, algo_creator_t creator) noexcept;
+      static bool Register(const std::string& name, algo_creator_t creator, const std::vector<std::string>& new_banks) noexcept;
 
       /// Create an algorithm. Throws an exception if the algorithm cannot be created
       /// @param name the name of the algorithm, which was used as an argument in the `AlgorithmFactory::Register` call
       /// @returns the algorithm instance
       static algo_t Create(const std::string& name) noexcept(false);
-
-      /// Register banks that are created by a creator-type algorithm
-      /// @param bank_names the list of new bank names
-      /// @param algo_name the name of the algorithm which creates the new banks
-      /// @returns true if successful
-      static bool RegisterNewBanks(const std::vector<std::string>& bank_names, const std::string& algo_name) noexcept;
 
       /// Check if a bank is created by an algorithm
       /// @param bank_name the name of the bank

--- a/src/iguana/algorithms/AlgorithmBoilerplate.h
+++ b/src/iguana/algorithms/AlgorithmBoilerplate.h
@@ -34,7 +34,8 @@
 
 /// Define the private members of an algorithm
 #define IGUANA_ALGORITHM_PRIVATE_MEMBERS \
-  static bool s_registered;
+  static bool s_registered;              \
+  static bool s_registered_as_creator;
 
 /////////////////////////////////////////////////////////////////////////////////
 
@@ -70,6 +71,12 @@ public:                                                                    \
 /// @param ALGO_NAME the name of the algorithm class
 #define REGISTER_IGUANA_ALGORITHM(ALGO_NAME) \
   bool ALGO_NAME::s_registered = AlgorithmFactory::Register(ALGO_NAME::GetClassName(), ALGO_NAME::Creator);
+
+/// Register banks created by this algorithm
+/// @param ALGO_NAME the name of the algorithm class
+/// @param ... the new banks
+#define REGISTER_IGUANA_NEW_BANKS(ALGO_NAME, ...) \
+  bool ALGO_NAME::s_registered_as_creator = AlgorithmFactory::RegisterNewBanks({__VA_ARGS__}, ALGO_NAME::GetClassName());
 
 /// Register a validator for the `iguana::AlgorithmFactory`, similar to `REGISTER_IGUANA_ALGORITHM`
 /// @param VDOR_NAME the name of the validator class

--- a/src/iguana/algorithms/AlgorithmBoilerplate.h
+++ b/src/iguana/algorithms/AlgorithmBoilerplate.h
@@ -34,8 +34,7 @@
 
 /// Define the private members of an algorithm
 #define IGUANA_ALGORITHM_PRIVATE_MEMBERS \
-  static bool s_registered;              \
-  static bool s_registered_as_creator;
+  static bool s_registered;
 
 /////////////////////////////////////////////////////////////////////////////////
 
@@ -69,14 +68,10 @@ public:                                                                    \
 
 /// Register an algorithm for the `iguana::AlgorithmFactory`; this macro should be called in the algorithm's implementation
 /// @param ALGO_NAME the name of the algorithm class
-#define REGISTER_IGUANA_ALGORITHM(ALGO_NAME) \
-  bool ALGO_NAME::s_registered = AlgorithmFactory::Register(ALGO_NAME::GetClassName(), ALGO_NAME::Creator);
-
-/// Register banks created by this algorithm
-/// @param ALGO_NAME the name of the algorithm class
-/// @param ... the new banks
-#define REGISTER_IGUANA_NEW_BANKS(ALGO_NAME, ...) \
-  bool ALGO_NAME::s_registered_as_creator = AlgorithmFactory::RegisterNewBanks({__VA_ARGS__}, ALGO_NAME::GetClassName());
+/// @param ... if this algorithm creates new banks, add their names here; this is a variadic parameter, so you may
+/// list as many as needed, or none.
+#define REGISTER_IGUANA_ALGORITHM(ALGO_NAME, ...) \
+  bool ALGO_NAME::s_registered = AlgorithmFactory::Register(ALGO_NAME::GetClassName(), ALGO_NAME::Creator, {__VA_ARGS__});
 
 /// Register a validator for the `iguana::AlgorithmFactory`, similar to `REGISTER_IGUANA_ALGORITHM`
 /// @param VDOR_NAME the name of the validator class

--- a/src/iguana/algorithms/AlgorithmFactory.cc
+++ b/src/iguana/algorithms/AlgorithmFactory.cc
@@ -3,6 +3,7 @@
 namespace iguana {
 
   std::unordered_map<std::string, AlgorithmFactory::algo_creator_t> AlgorithmFactory::s_creators;
+  std::unordered_map<std::string, std::vector<std::string>> AlgorithmFactory::s_created_banks;
 
   bool AlgorithmFactory::Register(const std::string& name, algo_creator_t creator) noexcept
   {
@@ -20,4 +21,20 @@ namespace iguana {
     throw std::runtime_error(fmt::format("AlgorithmFactory: algorithm with name {:?} does not exist", name));
   }
 
+  bool AlgorithmFactory::RegisterNewBanks(const std::vector<std::string>& bank_names, const std::string& algo_name) noexcept
+  {
+    for(const auto& bank_name : bank_names) {
+      if(auto it = s_created_banks.find(bank_name); it == s_created_banks.end())
+        s_created_banks.insert({bank_name, {}});
+      s_created_banks.at(bank_name).push_back(algo_name);
+    }
+    return true;
+  }
+
+  std::optional<std::vector<std::string>> AlgorithmFactory::QueryNewBank(const std::string& bank_name) noexcept
+  {
+    if(auto it = s_created_banks.find(bank_name); it != s_created_banks.end())
+      return it->second;
+    return {};
+  }
 }

--- a/src/iguana/algorithms/AlgorithmFactory.cc
+++ b/src/iguana/algorithms/AlgorithmFactory.cc
@@ -5,7 +5,7 @@ namespace iguana {
   std::unordered_map<std::string, AlgorithmFactory::algo_creator_t> AlgorithmFactory::s_creators;
   std::unordered_map<std::string, std::vector<std::string>> AlgorithmFactory::s_created_banks;
 
-  bool AlgorithmFactory::Register(const std::string& name, algo_creator_t creator, const std::vector<std::string>& new_banks) noexcept
+  bool AlgorithmFactory::Register(const std::string& name, algo_creator_t creator, const std::vector<std::string> new_banks) noexcept
   {
     if(auto it = s_creators.find(name); it == s_creators.end()) {
       s_creators.insert({name, creator});

--- a/src/iguana/algorithms/AlgorithmFactory.cc
+++ b/src/iguana/algorithms/AlgorithmFactory.cc
@@ -5,10 +5,15 @@ namespace iguana {
   std::unordered_map<std::string, AlgorithmFactory::algo_creator_t> AlgorithmFactory::s_creators;
   std::unordered_map<std::string, std::vector<std::string>> AlgorithmFactory::s_created_banks;
 
-  bool AlgorithmFactory::Register(const std::string& name, algo_creator_t creator) noexcept
+  bool AlgorithmFactory::Register(const std::string& name, algo_creator_t creator, const std::vector<std::string>& new_banks) noexcept
   {
     if(auto it = s_creators.find(name); it == s_creators.end()) {
       s_creators.insert({name, creator});
+      for(const auto& new_bank : new_banks) {
+        if(auto it = s_created_banks.find(new_bank); it == s_created_banks.end())
+          s_created_banks.insert({new_bank, {}});
+        s_created_banks.at(new_bank).push_back(name);
+      }
       return true;
     }
     return false;
@@ -19,16 +24,6 @@ namespace iguana {
     if(auto it = s_creators.find(name); it != s_creators.end())
       return it->second();
     throw std::runtime_error(fmt::format("AlgorithmFactory: algorithm with name {:?} does not exist", name));
-  }
-
-  bool AlgorithmFactory::RegisterNewBanks(const std::vector<std::string>& bank_names, const std::string& algo_name) noexcept
-  {
-    for(const auto& bank_name : bank_names) {
-      if(auto it = s_created_banks.find(bank_name); it == s_created_banks.end())
-        s_created_banks.insert({bank_name, {}});
-      s_created_banks.at(bank_name).push_back(algo_name);
-    }
-    return true;
   }
 
   std::optional<std::vector<std::string>> AlgorithmFactory::QueryNewBank(const std::string& bank_name) noexcept

--- a/src/iguana/algorithms/example/ExampleAlgorithm.cc
+++ b/src/iguana/algorithms/example/ExampleAlgorithm.cc
@@ -14,8 +14,11 @@ namespace iguana::example {
   // # - this must be done here in the source file, not in the header
   // # - the argument is the class name; do not surround it with quotes
   // # - usage of a semicolon at the end is optional, but recommended
+  // # - if this algorithm creates NEW banks, they also need to be registered;
+  // #   the preprocessor macro is variadic
   // ############################################################################
   REGISTER_IGUANA_ALGORITHM(ExampleAlgorithm);
+  REGISTER_IGUANA_NEW_BANKS(ExampleAlgorithm, "example::newBank1", "example::newBank2"); // (only needed if this algorithm creates a NEW bank)
 
   // ############################################################################
   // # define `ExampleAlgorithm::Start()`

--- a/src/iguana/algorithms/example/ExampleAlgorithm.cc
+++ b/src/iguana/algorithms/example/ExampleAlgorithm.cc
@@ -14,11 +14,12 @@ namespace iguana::example {
   // # - this must be done here in the source file, not in the header
   // # - the argument is the class name; do not surround it with quotes
   // # - usage of a semicolon at the end is optional, but recommended
-  // # - if this algorithm creates NEW banks, they also need to be registered;
-  // #   the preprocessor macro is variadic
+  // # - if this algorithm creates NEW banks, they also need to be registered by
+  // #   adding additional string arguments for their names; you may add as many
+  // #   new banks as you want
   // ############################################################################
   REGISTER_IGUANA_ALGORITHM(ExampleAlgorithm);
-  REGISTER_IGUANA_NEW_BANKS(ExampleAlgorithm, "example::newBank1", "example::newBank2"); // (only needed if this algorithm creates a NEW bank)
+  // REGISTER_IGUANA_ALGORITHM(ExampleAlgorithm , "example::newBank1", "example::newBank2"); // if this algorithm creates 2 new banks
 
   // ############################################################################
   // # define `ExampleAlgorithm::Start()`
@@ -42,6 +43,11 @@ namespace iguana::example {
     // #   avoid looking them up in the `Algorithm::Run` method
     // ############################################################################
     b_particle = GetBankIndex(banks, "REC::Particle");
+    // ############################################################################
+    // # if this algorithm creates any new banks, use the `CreateBank` function;
+    // # see API documentation or other algorithms for its usage
+    // ############################################################################
+    // CreateBank(.....); // use this to create a new bank
   }
 
 

--- a/src/iguana/algorithms/physics/InclusiveKinematics.cc
+++ b/src/iguana/algorithms/physics/InclusiveKinematics.cc
@@ -5,8 +5,7 @@
 
 namespace iguana::physics {
 
-  REGISTER_IGUANA_ALGORITHM(InclusiveKinematics);
-  REGISTER_IGUANA_NEW_BANKS(physics::InclusiveKinematics, "physics::InclusiveKinematics");
+  REGISTER_IGUANA_ALGORITHM(InclusiveKinematics, "physics::InclusiveKinematics");
 
   void InclusiveKinematics::Start(hipo::banklist& banks)
   {

--- a/src/iguana/algorithms/physics/InclusiveKinematics.cc
+++ b/src/iguana/algorithms/physics/InclusiveKinematics.cc
@@ -6,6 +6,7 @@
 namespace iguana::physics {
 
   REGISTER_IGUANA_ALGORITHM(InclusiveKinematics);
+  REGISTER_IGUANA_NEW_BANKS(physics::InclusiveKinematics, "physics::InclusiveKinematics");
 
   void InclusiveKinematics::Start(hipo::banklist& banks)
   {


### PR DESCRIPTION
If an algorithm depends on some _new_ bank created by another algorithm, the user should be informed of the requirement. This PR requires registration of created banks, so that the lookup of which algorithm(s) create them can be performed.