### PR TITLE
perf: replace `std::string const`-type parameters with `std::string_view`

### DIFF
--- a/src/iguana/algorithms/Algorithm.cc
+++ b/src/iguana/algorithms/Algorithm.cc
@@ -14,14 +14,14 @@ namespace iguana {
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  OPTION_TYPE Algorithm::GetOptionScalar(const std::string key, YAMLReader::node_path_t node_path)
+  OPTION_TYPE Algorithm::GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path)
   {
     try {
       CompleteOptionNodePath(key, node_path);
       auto opt = GetCachedOption<OPTION_TYPE>(key);
       auto val = opt ? opt.value() : m_yaml_config->GetScalar<OPTION_TYPE>(node_path);
       if(key != "") {
-        m_option_cache[key] = val;
+        m_option_cache[key.data()] = val;
         m_log->Debug("CACHED OPTION: {:>20} = {}", key, PrintOptionValue(key));
       }
       return val;
@@ -31,21 +31,21 @@ namespace iguana {
       throw std::runtime_error("config file parsing issue");
     }
   }
-  template int Algorithm::GetOptionScalar(const std::string key, YAMLReader::node_path_t node_path);
-  template double Algorithm::GetOptionScalar(const std::string key, YAMLReader::node_path_t node_path);
-  template std::string Algorithm::GetOptionScalar(const std::string key, YAMLReader::node_path_t node_path);
+  template int Algorithm::GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path);
+  template double Algorithm::GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path);
+  template std::string Algorithm::GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path);
 
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  std::vector<OPTION_TYPE> Algorithm::GetOptionVector(const std::string key, YAMLReader::node_path_t node_path)
+  std::vector<OPTION_TYPE> Algorithm::GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path)
   {
     try {
       CompleteOptionNodePath(key, node_path);
       auto opt = GetCachedOption<std::vector<OPTION_TYPE>>(key);
       auto val = opt ? opt.value() : m_yaml_config->GetVector<OPTION_TYPE>(node_path);
       if(key != "") {
-        m_option_cache[key] = val;
+        m_option_cache[key.data()] = val;
         m_log->Debug("CACHED OPTION: {:>20} = {}", key, PrintOptionValue(key));
       }
       return val;
@@ -55,27 +55,27 @@ namespace iguana {
       throw std::runtime_error("config file parsing issue");
     }
   }
-  template std::vector<int> Algorithm::GetOptionVector(const std::string key, YAMLReader::node_path_t node_path);
-  template std::vector<double> Algorithm::GetOptionVector(const std::string key, YAMLReader::node_path_t node_path);
-  template std::vector<std::string> Algorithm::GetOptionVector(const std::string key, YAMLReader::node_path_t node_path);
+  template std::vector<int> Algorithm::GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path);
+  template std::vector<double> Algorithm::GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path);
+  template std::vector<std::string> Algorithm::GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path);
 
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  std::set<OPTION_TYPE> Algorithm::GetOptionSet(const std::string key, YAMLReader::node_path_t node_path)
+  std::set<OPTION_TYPE> Algorithm::GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path)
   {
     auto val_vec = GetOptionVector<OPTION_TYPE>(key, node_path);
     std::set<OPTION_TYPE> val_set;
     std::copy(val_vec.begin(), val_vec.end(), std::inserter(val_set, val_set.end()));
     return val_set;
   }
-  template std::set<int> Algorithm::GetOptionSet(const std::string key, YAMLReader::node_path_t node_path);
-  template std::set<double> Algorithm::GetOptionSet(const std::string key, YAMLReader::node_path_t node_path);
-  template std::set<std::string> Algorithm::GetOptionSet(const std::string key, YAMLReader::node_path_t node_path);
+  template std::set<int> Algorithm::GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path);
+  template std::set<double> Algorithm::GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path);
+  template std::set<std::string> Algorithm::GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path);
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  void Algorithm::SetName(const std::string name)
+  void Algorithm::SetName(std::string_view name)
   {
     Object::SetName(name);
     if(m_yaml_config)
@@ -131,7 +131,7 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  hipo::banklist::size_type Algorithm::GetBankIndex(hipo::banklist& banks, const std::string bank_name) const
+  hipo::banklist::size_type Algorithm::GetBankIndex(hipo::banklist& banks, std::string_view bank_name) const
   {
     if(m_rows_only)
       return 0;
@@ -154,9 +154,9 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  std::string Algorithm::PrintOptionValue(const std::string key) const
+  std::string Algorithm::PrintOptionValue(std::string_view key) const
   {
-    if(auto it{m_option_cache.find(key)}; it != m_option_cache.end()) {
+    if(auto it{m_option_cache.find(key.data())}; it != m_option_cache.end()) {
       auto val = it->second;
       if(auto const valPtr(std::get_if<int>(&val)); valPtr)
         return fmt::format("{} [{}]", *valPtr, "int");
@@ -186,7 +186,7 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  hipo::bank& Algorithm::GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, const std::string expected_bank_name) const
+  hipo::bank& Algorithm::GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, std::string_view expected_bank_name) const
   {
     if(m_rows_only) {
       m_log->Error("algorithm is in 'rows only' mode; cannot call `Run` since banks are not cached; use action function(s) instead");
@@ -250,7 +250,7 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  void Algorithm::ShowBanks(hipo::banklist& banks, const std::string message, const Logger::Level level) const
+  void Algorithm::ShowBanks(hipo::banklist& banks, std::string_view message, const Logger::Level level) const
   {
     if(m_log->GetLevel() <= level) {
       if(message != "")
@@ -262,7 +262,7 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  void Algorithm::ShowBank(hipo::bank& bank, const std::string message, const Logger::Level level) const
+  void Algorithm::ShowBank(hipo::bank& bank, std::string_view message, const Logger::Level level) const
   {
     if(m_log->GetLevel() <= level) {
       if(message != "")
@@ -274,11 +274,11 @@ namespace iguana {
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  std::optional<OPTION_TYPE> Algorithm::GetCachedOption(const std::string key) const
+  std::optional<OPTION_TYPE> Algorithm::GetCachedOption(std::string_view key) const
   {
     if(key == "")
       return {};
-    if(auto it{m_option_cache.find(key)}; it != m_option_cache.end()) {
+    if(auto it{m_option_cache.find(key.data())}; it != m_option_cache.end()) {
       try { // get the expected type
         return std::get<OPTION_TYPE>(it->second);
       }
@@ -288,19 +288,19 @@ namespace iguana {
     }
     return {};
   }
-  template std::optional<int> Algorithm::GetCachedOption(const std::string key) const;
-  template std::optional<double> Algorithm::GetCachedOption(const std::string key) const;
-  template std::optional<std::string> Algorithm::GetCachedOption(const std::string key) const;
-  template std::optional<std::vector<int>> Algorithm::GetCachedOption(const std::string key) const;
-  template std::optional<std::vector<double>> Algorithm::GetCachedOption(const std::string key) const;
-  template std::optional<std::vector<std::string>> Algorithm::GetCachedOption(const std::string key) const;
+  template std::optional<int> Algorithm::GetCachedOption(std::string_view key) const;
+  template std::optional<double> Algorithm::GetCachedOption(std::string_view key) const;
+  template std::optional<std::string> Algorithm::GetCachedOption(std::string_view key) const;
+  template std::optional<std::vector<int>> Algorithm::GetCachedOption(std::string_view key) const;
+  template std::optional<std::vector<double>> Algorithm::GetCachedOption(std::string_view key) const;
+  template std::optional<std::vector<std::string>> Algorithm::GetCachedOption(std::string_view key) const;
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  void Algorithm::CompleteOptionNodePath(const std::string key, YAMLReader::node_path_t& node_path) const
+  void Algorithm::CompleteOptionNodePath(std::string_view key, YAMLReader::node_path_t& node_path) const
   {
     if(node_path.empty())
-      node_path.push_front(key);
+      node_path.push_front(key.data());
     node_path.push_front(m_class_name);
   }
 }

--- a/src/iguana/algorithms/Algorithm.cc
+++ b/src/iguana/algorithms/Algorithm.cc
@@ -14,14 +14,14 @@ namespace iguana {
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  OPTION_TYPE Algorithm::GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path)
+  OPTION_TYPE Algorithm::GetOptionScalar(std::string const& key, YAMLReader::node_path_t node_path)
   {
     try {
       CompleteOptionNodePath(key, node_path);
       auto opt = GetCachedOption<OPTION_TYPE>(key);
       auto val = opt ? opt.value() : m_yaml_config->GetScalar<OPTION_TYPE>(node_path);
       if(key != "") {
-        m_option_cache[key.data()] = val;
+        m_option_cache[key] = val;
         m_log->Debug("CACHED OPTION: {:>20} = {}", key, PrintOptionValue(key));
       }
       return val;
@@ -31,21 +31,21 @@ namespace iguana {
       throw std::runtime_error("config file parsing issue");
     }
   }
-  template int Algorithm::GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path);
-  template double Algorithm::GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path);
-  template std::string Algorithm::GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path);
+  template int Algorithm::GetOptionScalar(std::string const& key, YAMLReader::node_path_t node_path);
+  template double Algorithm::GetOptionScalar(std::string const& key, YAMLReader::node_path_t node_path);
+  template std::string Algorithm::GetOptionScalar(std::string const& key, YAMLReader::node_path_t node_path);
 
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  std::vector<OPTION_TYPE> Algorithm::GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path)
+  std::vector<OPTION_TYPE> Algorithm::GetOptionVector(std::string const& key, YAMLReader::node_path_t node_path)
   {
     try {
       CompleteOptionNodePath(key, node_path);
       auto opt = GetCachedOption<std::vector<OPTION_TYPE>>(key);
       auto val = opt ? opt.value() : m_yaml_config->GetVector<OPTION_TYPE>(node_path);
       if(key != "") {
-        m_option_cache[key.data()] = val;
+        m_option_cache[key] = val;
         m_log->Debug("CACHED OPTION: {:>20} = {}", key, PrintOptionValue(key));
       }
       return val;
@@ -55,23 +55,23 @@ namespace iguana {
       throw std::runtime_error("config file parsing issue");
     }
   }
-  template std::vector<int> Algorithm::GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path);
-  template std::vector<double> Algorithm::GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path);
-  template std::vector<std::string> Algorithm::GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path);
+  template std::vector<int> Algorithm::GetOptionVector(std::string const& key, YAMLReader::node_path_t node_path);
+  template std::vector<double> Algorithm::GetOptionVector(std::string const& key, YAMLReader::node_path_t node_path);
+  template std::vector<std::string> Algorithm::GetOptionVector(std::string const& key, YAMLReader::node_path_t node_path);
 
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  std::set<OPTION_TYPE> Algorithm::GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path)
+  std::set<OPTION_TYPE> Algorithm::GetOptionSet(std::string const& key, YAMLReader::node_path_t node_path)
   {
     auto val_vec = GetOptionVector<OPTION_TYPE>(key, node_path);
     std::set<OPTION_TYPE> val_set;
     std::copy(val_vec.begin(), val_vec.end(), std::inserter(val_set, val_set.end()));
     return val_set;
   }
-  template std::set<int> Algorithm::GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path);
-  template std::set<double> Algorithm::GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path);
-  template std::set<std::string> Algorithm::GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path);
+  template std::set<int> Algorithm::GetOptionSet(std::string const& key, YAMLReader::node_path_t node_path);
+  template std::set<double> Algorithm::GetOptionSet(std::string const& key, YAMLReader::node_path_t node_path);
+  template std::set<std::string> Algorithm::GetOptionSet(std::string const& key, YAMLReader::node_path_t node_path);
 
   ///////////////////////////////////////////////////////////////////////////////
 
@@ -131,7 +131,7 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  hipo::banklist::size_type Algorithm::GetBankIndex(hipo::banklist& banks, std::string_view bank_name) const
+  hipo::banklist::size_type Algorithm::GetBankIndex(hipo::banklist& banks, std::string const& bank_name) const
   {
     if(m_rows_only)
       return 0;
@@ -154,9 +154,9 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  std::string Algorithm::PrintOptionValue(std::string_view key) const
+  std::string Algorithm::PrintOptionValue(std::string const& key) const
   {
-    if(auto it{m_option_cache.find(key.data())}; it != m_option_cache.end()) {
+    if(auto it{m_option_cache.find(key)}; it != m_option_cache.end()) {
       auto val = it->second;
       if(auto const valPtr(std::get_if<int>(&val)); valPtr)
         return fmt::format("{} [{}]", *valPtr, "int");
@@ -186,7 +186,7 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  hipo::bank& Algorithm::GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, std::string_view expected_bank_name) const
+  hipo::bank& Algorithm::GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, std::string const& expected_bank_name) const
   {
     if(m_rows_only) {
       m_log->Error("algorithm is in 'rows only' mode; cannot call `Run` since banks are not cached; use action function(s) instead");
@@ -223,7 +223,7 @@ namespace iguana {
   hipo::schema Algorithm::CreateBank(
       hipo::banklist& banks,
       hipo::banklist::size_type& bank_idx,
-      std::string bank_name,
+      std::string const& bank_name,
       std::vector<std::string> schema_def,
       int group_id,
       int item_id) const
@@ -274,11 +274,11 @@ namespace iguana {
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename OPTION_TYPE>
-  std::optional<OPTION_TYPE> Algorithm::GetCachedOption(std::string_view key) const
+  std::optional<OPTION_TYPE> Algorithm::GetCachedOption(std::string const& key) const
   {
     if(key == "")
       return {};
-    if(auto it{m_option_cache.find(key.data())}; it != m_option_cache.end()) {
+    if(auto it{m_option_cache.find(key)}; it != m_option_cache.end()) {
       try { // get the expected type
         return std::get<OPTION_TYPE>(it->second);
       }
@@ -288,19 +288,19 @@ namespace iguana {
     }
     return {};
   }
-  template std::optional<int> Algorithm::GetCachedOption(std::string_view key) const;
-  template std::optional<double> Algorithm::GetCachedOption(std::string_view key) const;
-  template std::optional<std::string> Algorithm::GetCachedOption(std::string_view key) const;
-  template std::optional<std::vector<int>> Algorithm::GetCachedOption(std::string_view key) const;
-  template std::optional<std::vector<double>> Algorithm::GetCachedOption(std::string_view key) const;
-  template std::optional<std::vector<std::string>> Algorithm::GetCachedOption(std::string_view key) const;
+  template std::optional<int> Algorithm::GetCachedOption(std::string const& key) const;
+  template std::optional<double> Algorithm::GetCachedOption(std::string const& key) const;
+  template std::optional<std::string> Algorithm::GetCachedOption(std::string const& key) const;
+  template std::optional<std::vector<int>> Algorithm::GetCachedOption(std::string const& key) const;
+  template std::optional<std::vector<double>> Algorithm::GetCachedOption(std::string const& key) const;
+  template std::optional<std::vector<std::string>> Algorithm::GetCachedOption(std::string const& key) const;
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  void Algorithm::CompleteOptionNodePath(std::string_view key, YAMLReader::node_path_t& node_path) const
+  void Algorithm::CompleteOptionNodePath(std::string const& key, YAMLReader::node_path_t& node_path) const
   {
     if(node_path.empty())
-      node_path.push_front(key.data());
+      node_path.push_front(key);
     node_path.push_front(m_class_name);
   }
 }

--- a/src/iguana/algorithms/Algorithm.cc
+++ b/src/iguana/algorithms/Algorithm.cc
@@ -98,14 +98,14 @@ namespace iguana {
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  void Algorithm::SetConfigFile(std::string name)
+  void Algorithm::SetConfigFile(std::string const& name)
   {
     o_user_config_file = SetOption("config_file", name);
   }
 
   ///////////////////////////////////////////////////////////////////////////////
 
-  void Algorithm::SetConfigDirectory(std::string name)
+  void Algorithm::SetConfigDirectory(std::string const& name)
   {
     o_user_config_dir = SetOption("config_dir", name);
   }

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -76,7 +76,7 @@ namespace iguana {
       /// @param val the value to set
       /// @returns the value that has been set (if needed, _e.g._, when `val` is an rvalue)
       template <typename OPTION_TYPE>
-      OPTION_TYPE SetOption(std::string_view key, const OPTION_TYPE val)
+      OPTION_TYPE SetOption(std::string const& key, const OPTION_TYPE val)
       {
         // FIXME: this template is not specialized, to be friendlier to python `cppyy` bindings
         if(key == "log") {
@@ -89,7 +89,7 @@ namespace iguana {
             m_log->Error("Option '{}' must be a string or a Logger::Level", key);
         }
         else {
-          m_option_cache[key.data()] = val;
+          m_option_cache[key] = val;
           m_log->Debug("  USER OPTION: {:>20} = {}", key, PrintOptionValue(key));
         }
         return val;
@@ -100,21 +100,21 @@ namespace iguana {
       /// @param node_path the `YAML::Node` identifier path to search for this option in the config files; if empty, it will just use `key`
       /// @returns the scalar option
       template <typename OPTION_TYPE>
-      OPTION_TYPE GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path = {});
+      OPTION_TYPE GetOptionScalar(std::string const& key, YAMLReader::node_path_t node_path = {});
 
       /// Get the value of a vector option
       /// @param key the unique key name of this option, for caching; if empty, the option will not be cached
       /// @param node_path the `YAML::Node` identifier path to search for this option in the config files; if empty, it will just use `key`
       /// @returns the vector option
       template <typename OPTION_TYPE>
-      std::vector<OPTION_TYPE> GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path = {});
+      std::vector<OPTION_TYPE> GetOptionVector(std::string const& key, YAMLReader::node_path_t node_path = {});
 
       /// Get the value of a vector option, and convert it to `std::set`
       /// @param key the unique key name of this option
       /// @param node_path the `YAML::Node` identifier path to search for this option in the config files; if empty, it will just use `key`
       /// @returns the vector option converted to `std::set`
       template <typename OPTION_TYPE>
-      std::set<OPTION_TYPE> GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path = {});
+      std::set<OPTION_TYPE> GetOptionSet(std::string const& key, YAMLReader::node_path_t node_path = {});
 
       /// Set the name of this algorithm
       /// @param name the new name
@@ -145,19 +145,19 @@ namespace iguana {
       /// @param banks the list of banks this algorithm will use
       /// @param bank_name the name of the bank
       /// returns the `hipo::banklist` index of the bank
-      hipo::banklist::size_type GetBankIndex(hipo::banklist& banks, std::string_view bank_name) const noexcept(false);
+      hipo::banklist::size_type GetBankIndex(hipo::banklist& banks, std::string const& bank_name) const noexcept(false);
 
       /// Return a string with the value of an option along with its type
       /// @param key the name of the option
       /// @return the string value and its type
-      std::string PrintOptionValue(std::string_view key) const;
+      std::string PrintOptionValue(std::string const& key) const;
 
       /// Get the reference to a bank from a `hipo::banklist`; optionally checks if the bank name matches the expectation
       /// @param banks the `hipo::banklist` from which to get the specified bank
       /// @param idx the index of `banks` of the specified bank
       /// @param expected_bank_name if specified, checks that the specified bank has this name
       /// @return a reference to the bank
-      hipo::bank& GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, std::string_view expected_bank_name = "") const noexcept(false);
+      hipo::bank& GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, std::string const& expected_bank_name = "") const noexcept(false);
 
       /// Mask a row, setting all items to zero
       /// @param bank the bank to modify
@@ -175,7 +175,7 @@ namespace iguana {
       hipo::schema CreateBank(
           hipo::banklist& banks,
           hipo::banklist::size_type& bank_idx,
-          std::string bank_name,
+          std::string const& bank_name,
           std::vector<std::string> schema_def,
           int group_id, // FIXME: generalize group_id and item_id setting
           int item_id) const noexcept(false);
@@ -196,14 +196,14 @@ namespace iguana {
       /// @param key the key name associated with this option
       /// @returns the option value, if found (using `std::optional`)
       template <typename OPTION_TYPE>
-      std::optional<OPTION_TYPE> GetCachedOption(std::string_view key) const;
+      std::optional<OPTION_TYPE> GetCachedOption(std::string const& key) const;
 
     private: // methods
 
       /// Prepend `node_path` with the full algorithm name. If `node_path` is empty, set it to `{key}`.
       /// @param key the key name for this option
       /// @param node_path the `YAMLReader::node_path_t` to prepend
-      void CompleteOptionNodePath(std::string_view key, YAMLReader::node_path_t& node_path) const;
+      void CompleteOptionNodePath(std::string const& key, YAMLReader::node_path_t& node_path) const;
 
     protected: // members
 
@@ -254,17 +254,17 @@ namespace iguana {
       /// @param creator the creator function
       /// @param new_banks if this algorithm creates *new* banks, list them here
       /// @returns true if the algorithm has not yet been registered
-      static bool Register(std::string_view name, algo_creator_t creator, const std::vector<std::string> new_banks = {}) noexcept;
+      static bool Register(std::string const& name, algo_creator_t creator, const std::vector<std::string> new_banks = {}) noexcept;
 
       /// Create an algorithm. Throws an exception if the algorithm cannot be created
       /// @param name the name of the algorithm, which was used as an argument in the `AlgorithmFactory::Register` call
       /// @returns the algorithm instance
-      static algo_t Create(std::string_view name) noexcept(false);
+      static algo_t Create(std::string const& name) noexcept(false);
 
       /// Check if a bank is created by an algorithm
       /// @param bank_name the name of the bank
       /// @returns the list of algorithms which create it, if any
-      static std::optional<std::vector<std::string>> QueryNewBank(std::string_view bank_name) noexcept;
+      static std::optional<std::vector<std::string>> QueryNewBank(std::string const& bank_name) noexcept;
 
     private:
 

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -130,11 +130,11 @@ namespace iguana {
 
       /// Set a custom configuration file for this algorithm; see also `Algorithm::SetConfigDirectory`
       /// @param name the configuration file name
-      void SetConfigFile(std::string name);
+      void SetConfigFile(std::string const& name);
 
       /// Set a custom configuration file directory for this algorithm; see also `Algorithm::SetConfigFile`
       /// @param name the directory name
-      void SetConfigDirectory(std::string name);
+      void SetConfigDirectory(std::string const& name);
 
     protected: // methods
 

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -44,7 +44,7 @@ namespace iguana {
     public:
 
       /// @param name the unique name for a derived class instance
-      Algorithm(const std::string name)
+      Algorithm(std::string_view name)
           : Object(name)
           , m_rows_only(false)
           , m_default_config_file("")
@@ -76,7 +76,7 @@ namespace iguana {
       /// @param val the value to set
       /// @returns the value that has been set (if needed, _e.g._, when `val` is an rvalue)
       template <typename OPTION_TYPE>
-      OPTION_TYPE SetOption(const std::string key, const OPTION_TYPE val)
+      OPTION_TYPE SetOption(std::string_view key, const OPTION_TYPE val)
       {
         // FIXME: this template is not specialized, to be friendlier to python `cppyy` bindings
         if(key == "log") {
@@ -89,7 +89,7 @@ namespace iguana {
             m_log->Error("Option '{}' must be a string or a Logger::Level", key);
         }
         else {
-          m_option_cache[key] = val;
+          m_option_cache[key.data()] = val;
           m_log->Debug("  USER OPTION: {:>20} = {}", key, PrintOptionValue(key));
         }
         return val;
@@ -100,25 +100,25 @@ namespace iguana {
       /// @param node_path the `YAML::Node` identifier path to search for this option in the config files; if empty, it will just use `key`
       /// @returns the scalar option
       template <typename OPTION_TYPE>
-      OPTION_TYPE GetOptionScalar(const std::string key, YAMLReader::node_path_t node_path = {});
+      OPTION_TYPE GetOptionScalar(std::string_view key, YAMLReader::node_path_t node_path = {});
 
       /// Get the value of a vector option
       /// @param key the unique key name of this option, for caching; if empty, the option will not be cached
       /// @param node_path the `YAML::Node` identifier path to search for this option in the config files; if empty, it will just use `key`
       /// @returns the vector option
       template <typename OPTION_TYPE>
-      std::vector<OPTION_TYPE> GetOptionVector(const std::string key, YAMLReader::node_path_t node_path = {});
+      std::vector<OPTION_TYPE> GetOptionVector(std::string_view key, YAMLReader::node_path_t node_path = {});
 
       /// Get the value of a vector option, and convert it to `std::set`
       /// @param key the unique key name of this option
       /// @param node_path the `YAML::Node` identifier path to search for this option in the config files; if empty, it will just use `key`
       /// @returns the vector option converted to `std::set`
       template <typename OPTION_TYPE>
-      std::set<OPTION_TYPE> GetOptionSet(const std::string key, YAMLReader::node_path_t node_path = {});
+      std::set<OPTION_TYPE> GetOptionSet(std::string_view key, YAMLReader::node_path_t node_path = {});
 
       /// Set the name of this algorithm
       /// @param name the new name
-      void SetName(const std::string name);
+      void SetName(std::string_view name);
 
       /// Get a reference to this algorithm's configuration (`YAMLReader`)
       /// @returns the configuration
@@ -145,19 +145,19 @@ namespace iguana {
       /// @param banks the list of banks this algorithm will use
       /// @param bank_name the name of the bank
       /// returns the `hipo::banklist` index of the bank
-      hipo::banklist::size_type GetBankIndex(hipo::banklist& banks, const std::string bank_name) const noexcept(false);
+      hipo::banklist::size_type GetBankIndex(hipo::banklist& banks, std::string_view bank_name) const noexcept(false);
 
       /// Return a string with the value of an option along with its type
       /// @param key the name of the option
       /// @return the string value and its type
-      std::string PrintOptionValue(const std::string key) const;
+      std::string PrintOptionValue(std::string_view key) const;
 
       /// Get the reference to a bank from a `hipo::banklist`; optionally checks if the bank name matches the expectation
       /// @param banks the `hipo::banklist` from which to get the specified bank
       /// @param idx the index of `banks` of the specified bank
       /// @param expected_bank_name if specified, checks that the specified bank has this name
       /// @return a reference to the bank
-      hipo::bank& GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, const std::string expected_bank_name = "") const noexcept(false);
+      hipo::bank& GetBank(hipo::banklist& banks, const hipo::banklist::size_type idx, std::string_view expected_bank_name = "") const noexcept(false);
 
       /// Mask a row, setting all items to zero
       /// @param bank the bank to modify
@@ -184,26 +184,26 @@ namespace iguana {
       /// @param banks the banks to show
       /// @param message if specified, print a header message
       /// @param level the log level
-      void ShowBanks(hipo::banklist& banks, const std::string message = "", const Logger::Level level = Logger::trace) const;
+      void ShowBanks(hipo::banklist& banks, std::string_view message = "", const Logger::Level level = Logger::trace) const;
 
       /// Dump a single bank
       /// @param bank the bank to show
       /// @param message if specified, print a header message
       /// @param level the log level
-      void ShowBank(hipo::bank& bank, const std::string message = "", const Logger::Level level = Logger::trace) const;
+      void ShowBank(hipo::bank& bank, std::string_view message = "", const Logger::Level level = Logger::trace) const;
 
       /// Get an option from the option cache
       /// @param key the key name associated with this option
       /// @returns the option value, if found (using `std::optional`)
       template <typename OPTION_TYPE>
-      std::optional<OPTION_TYPE> GetCachedOption(const std::string key) const;
+      std::optional<OPTION_TYPE> GetCachedOption(std::string_view key) const;
 
     private: // methods
 
       /// Prepend `node_path` with the full algorithm name. If `node_path` is empty, set it to `{key}`.
       /// @param key the key name for this option
       /// @param node_path the `YAMLReader::node_path_t` to prepend
-      void CompleteOptionNodePath(const std::string key, YAMLReader::node_path_t& node_path) const;
+      void CompleteOptionNodePath(std::string_view key, YAMLReader::node_path_t& node_path) const;
 
     protected: // members
 
@@ -254,17 +254,17 @@ namespace iguana {
       /// @param creator the creator function
       /// @param new_banks if this algorithm creates *new* banks, list them here
       /// @returns true if the algorithm has not yet been registered
-      static bool Register(std::string const& name, algo_creator_t creator, const std::vector<std::string> new_banks = {}) noexcept;
+      static bool Register(std::string_view name, algo_creator_t creator, const std::vector<std::string> new_banks = {}) noexcept;
 
       /// Create an algorithm. Throws an exception if the algorithm cannot be created
       /// @param name the name of the algorithm, which was used as an argument in the `AlgorithmFactory::Register` call
       /// @returns the algorithm instance
-      static algo_t Create(std::string const& name) noexcept(false);
+      static algo_t Create(std::string_view name) noexcept(false);
 
       /// Check if a bank is created by an algorithm
       /// @param bank_name the name of the bank
       /// @returns the list of algorithms which create it, if any
-      static std::optional<std::vector<std::string>> QueryNewBank(std::string const& bank_name) noexcept;
+      static std::optional<std::vector<std::string>> QueryNewBank(std::string_view bank_name) noexcept;
 
     private:
 

--- a/src/iguana/algorithms/AlgorithmBoilerplate.h
+++ b/src/iguana/algorithms/AlgorithmBoilerplate.h
@@ -5,7 +5,7 @@
 /// @param ALGO_NAME the name of the algorithm class
 /// @param BASE_NAME the name of the base class
 #define CONSTRUCT_IGUANA_ALGORITHM(ALGO_NAME, BASE_NAME) \
-  ALGO_NAME(std::string name = "")                       \
+  ALGO_NAME(std::string_view name = "")                  \
       : BASE_NAME(name == "" ? GetClassName() : name)    \
   {                                                      \
     m_default_config_file = GetDefaultConfigFile();      \

--- a/src/iguana/algorithms/AlgorithmFactory.cc
+++ b/src/iguana/algorithms/AlgorithmFactory.cc
@@ -5,30 +5,30 @@ namespace iguana {
   std::unordered_map<std::string, AlgorithmFactory::algo_creator_t> AlgorithmFactory::s_creators;
   std::unordered_map<std::string, std::vector<std::string>> AlgorithmFactory::s_created_banks;
 
-  bool AlgorithmFactory::Register(std::string_view name, algo_creator_t creator, const std::vector<std::string> new_banks) noexcept
+  bool AlgorithmFactory::Register(std::string const& name, algo_creator_t creator, const std::vector<std::string> new_banks) noexcept
   {
-    if(auto it = s_creators.find(name.data()); it == s_creators.end()) {
-      s_creators.insert({name.data(), creator});
+    if(auto it = s_creators.find(name); it == s_creators.end()) {
+      s_creators.insert({name, creator});
       for(auto const& new_bank : new_banks) {
         if(auto it = s_created_banks.find(new_bank); it == s_created_banks.end())
           s_created_banks.insert({new_bank, {}});
-        s_created_banks.at(new_bank).push_back(name.data());
+        s_created_banks.at(new_bank).push_back(name);
       }
       return true;
     }
     return false;
   }
 
-  algo_t AlgorithmFactory::Create(std::string_view name)
+  algo_t AlgorithmFactory::Create(std::string const& name)
   {
-    if(auto it = s_creators.find(name.data()); it != s_creators.end())
+    if(auto it = s_creators.find(name); it != s_creators.end())
       return it->second();
     throw std::runtime_error(fmt::format("AlgorithmFactory: algorithm with name {:?} does not exist", name));
   }
 
-  std::optional<std::vector<std::string>> AlgorithmFactory::QueryNewBank(std::string_view bank_name) noexcept
+  std::optional<std::vector<std::string>> AlgorithmFactory::QueryNewBank(std::string const& bank_name) noexcept
   {
-    if(auto it = s_created_banks.find(bank_name.data()); it != s_created_banks.end())
+    if(auto it = s_created_banks.find(bank_name); it != s_created_banks.end())
       return it->second;
     return {};
   }

--- a/src/iguana/algorithms/AlgorithmFactory.cc
+++ b/src/iguana/algorithms/AlgorithmFactory.cc
@@ -5,30 +5,30 @@ namespace iguana {
   std::unordered_map<std::string, AlgorithmFactory::algo_creator_t> AlgorithmFactory::s_creators;
   std::unordered_map<std::string, std::vector<std::string>> AlgorithmFactory::s_created_banks;
 
-  bool AlgorithmFactory::Register(std::string const& name, algo_creator_t creator, const std::vector<std::string> new_banks) noexcept
+  bool AlgorithmFactory::Register(std::string_view name, algo_creator_t creator, const std::vector<std::string> new_banks) noexcept
   {
-    if(auto it = s_creators.find(name); it == s_creators.end()) {
-      s_creators.insert({name, creator});
+    if(auto it = s_creators.find(name.data()); it == s_creators.end()) {
+      s_creators.insert({name.data(), creator});
       for(auto const& new_bank : new_banks) {
         if(auto it = s_created_banks.find(new_bank); it == s_created_banks.end())
           s_created_banks.insert({new_bank, {}});
-        s_created_banks.at(new_bank).push_back(name);
+        s_created_banks.at(new_bank).push_back(name.data());
       }
       return true;
     }
     return false;
   }
 
-  algo_t AlgorithmFactory::Create(std::string const& name)
+  algo_t AlgorithmFactory::Create(std::string_view name)
   {
-    if(auto it = s_creators.find(name); it != s_creators.end())
+    if(auto it = s_creators.find(name.data()); it != s_creators.end())
       return it->second();
     throw std::runtime_error(fmt::format("AlgorithmFactory: algorithm with name {:?} does not exist", name));
   }
 
-  std::optional<std::vector<std::string>> AlgorithmFactory::QueryNewBank(std::string const& bank_name) noexcept
+  std::optional<std::vector<std::string>> AlgorithmFactory::QueryNewBank(std::string_view bank_name) noexcept
   {
-    if(auto it = s_created_banks.find(bank_name); it != s_created_banks.end())
+    if(auto it = s_created_banks.find(bank_name.data()); it != s_created_banks.end())
       return it->second;
     return {};
   }

--- a/src/iguana/algorithms/AlgorithmSequence.cc
+++ b/src/iguana/algorithms/AlgorithmSequence.cc
@@ -20,7 +20,7 @@ namespace iguana {
       algo->Stop();
   }
 
-  void AlgorithmSequence::Add(const std::string class_name, const std::string instance_name)
+  void AlgorithmSequence::Add(std::string_view class_name, std::string_view instance_name)
   {
     auto algo = AlgorithmFactory::Create(class_name);
     if(algo == nullptr) {
@@ -46,15 +46,15 @@ namespace iguana {
     }
   }
 
-  void AlgorithmSequence::SetName(const std::string name)
+  void AlgorithmSequence::SetName(std::string_view name)
   {
     // change the `m_name+"|"` prefix of each algorithm
     for(auto const& algo : m_sequence) {
       auto algoName = algo->GetName();
       if(auto pos{algoName.find("|")}; pos != algoName.npos)
-        algo->SetName(name + algoName.substr(pos));
+        algo->SetName(name.data() + algoName.substr(pos));
       else
-        algo->SetName(name + "|" + algoName);
+        algo->SetName(name.data() + std::string("|") + algoName);
     }
     // then change the object name
     Algorithm::SetName(name);

--- a/src/iguana/algorithms/AlgorithmSequence.cc
+++ b/src/iguana/algorithms/AlgorithmSequence.cc
@@ -20,7 +20,7 @@ namespace iguana {
       algo->Stop();
   }
 
-  void AlgorithmSequence::Add(std::string_view class_name, std::string_view instance_name)
+  void AlgorithmSequence::Add(std::string const& class_name, std::string_view instance_name)
   {
     auto algo = AlgorithmFactory::Create(class_name);
     if(algo == nullptr) {
@@ -52,9 +52,9 @@ namespace iguana {
     for(auto const& algo : m_sequence) {
       auto algoName = algo->GetName();
       if(auto pos{algoName.find("|")}; pos != algoName.npos)
-        algo->SetName(name.data() + algoName.substr(pos));
+        algo->SetName(std::string(name) + algoName.substr(pos));
       else
-        algo->SetName(name.data() + std::string("|") + algoName);
+        algo->SetName(std::string(name) + "|" + algoName);
     }
     // then change the object name
     Algorithm::SetName(name);

--- a/src/iguana/algorithms/AlgorithmSequence.cc
+++ b/src/iguana/algorithms/AlgorithmSequence.cc
@@ -20,7 +20,7 @@ namespace iguana {
       algo->Stop();
   }
 
-  void AlgorithmSequence::Add(std::string const& class_name, std::string_view instance_name)
+  void AlgorithmSequence::Add(std::string const& class_name, std::string const& instance_name)
   {
     auto algo = AlgorithmFactory::Create(class_name);
     if(algo == nullptr) {

--- a/src/iguana/algorithms/AlgorithmSequence.h
+++ b/src/iguana/algorithms/AlgorithmSequence.h
@@ -28,7 +28,7 @@ namespace iguana {
       /// @param class_name the name of the algorithm class
       /// @param instance_name a user-specified unique name for this algorithm instance;
       ///        if not specified, `class_name` will be used
-      void Add(std::string const& class_name, std::string_view instance_name = "");
+      void Add(std::string const& class_name, std::string const& instance_name = "");
 
       /// Create and add an algorithm to the sequence.
       ///

--- a/src/iguana/algorithms/AlgorithmSequence.h
+++ b/src/iguana/algorithms/AlgorithmSequence.h
@@ -28,7 +28,7 @@ namespace iguana {
       /// @param class_name the name of the algorithm class
       /// @param instance_name a user-specified unique name for this algorithm instance;
       ///        if not specified, `class_name` will be used
-      void Add(std::string_view class_name, std::string_view instance_name = "");
+      void Add(std::string const& class_name, std::string_view instance_name = "");
 
       /// Create and add an algorithm to the sequence.
       ///
@@ -66,9 +66,9 @@ namespace iguana {
       /// @param instance_name the instance name of the algorithm
       /// @return a reference to the algorithm
       template <class ALGORITHM>
-      ALGORITHM* Get(std::string_view instance_name)
+      ALGORITHM* Get(std::string const& instance_name)
       {
-        if(auto it{m_algo_names.find(instance_name.data())}; it != m_algo_names.end())
+        if(auto it{m_algo_names.find(instance_name)}; it != m_algo_names.end())
           return dynamic_cast<ALGORITHM*>(m_sequence[it->second].get());
         m_log->Error("cannot find algorithm '{}' in sequence", instance_name);
         throw std::runtime_error("cannot Get algorithm");
@@ -80,7 +80,7 @@ namespace iguana {
       /// @param key the option name
       /// @param val the option value
       template <typename OPTION_TYPE>
-      void SetOption(std::string_view algo_name, std::string_view key, const OPTION_TYPE val)
+      void SetOption(std::string const& algo_name, std::string const& key, const OPTION_TYPE val)
       {
         Get<Algorithm>(algo_name)->SetOption(key, val);
       }

--- a/src/iguana/algorithms/AlgorithmSequence.h
+++ b/src/iguana/algorithms/AlgorithmSequence.h
@@ -28,7 +28,7 @@ namespace iguana {
       /// @param class_name the name of the algorithm class
       /// @param instance_name a user-specified unique name for this algorithm instance;
       ///        if not specified, `class_name` will be used
-      void Add(const std::string class_name, const std::string instance_name = "");
+      void Add(std::string_view class_name, std::string_view instance_name = "");
 
       /// Create and add an algorithm to the sequence.
       ///
@@ -39,7 +39,7 @@ namespace iguana {
       /// @param instance_name a user-specified unique name for this algorithm instance;
       ///        if not specified, the class name will be used
       template <class ALGORITHM>
-      void Add(const std::string instance_name = "")
+      void Add(std::string_view instance_name = "")
       {
         if(instance_name == "")
           Add(std::make_unique<ALGORITHM>());
@@ -66,9 +66,9 @@ namespace iguana {
       /// @param instance_name the instance name of the algorithm
       /// @return a reference to the algorithm
       template <class ALGORITHM>
-      ALGORITHM* Get(const std::string instance_name)
+      ALGORITHM* Get(std::string_view instance_name)
       {
-        if(auto it{m_algo_names.find(instance_name)}; it != m_algo_names.end())
+        if(auto it{m_algo_names.find(instance_name.data())}; it != m_algo_names.end())
           return dynamic_cast<ALGORITHM*>(m_sequence[it->second].get());
         m_log->Error("cannot find algorithm '{}' in sequence", instance_name);
         throw std::runtime_error("cannot Get algorithm");
@@ -80,14 +80,14 @@ namespace iguana {
       /// @param key the option name
       /// @param val the option value
       template <typename OPTION_TYPE>
-      void SetOption(const std::string algo_name, const std::string key, const OPTION_TYPE val)
+      void SetOption(std::string_view algo_name, std::string_view key, const OPTION_TYPE val)
       {
         Get<Algorithm>(algo_name)->SetOption(key, val);
       }
 
       /// Set the name of this sequence
       /// @param name the new name
-      void SetName(const std::string name);
+      void SetName(std::string_view name);
 
       /// Print the names of the algorithms in this sequence
       /// @param level the log level of the printout

--- a/src/iguana/algorithms/Validator.cc
+++ b/src/iguana/algorithms/Validator.cc
@@ -2,7 +2,7 @@
 
 namespace iguana {
 
-  void Validator::SetOutputDirectory(std::string output_dir)
+  void Validator::SetOutputDirectory(std::string_view output_dir)
   {
     m_output_dir = output_dir;
   }

--- a/src/iguana/algorithms/Validator.h
+++ b/src/iguana/algorithms/Validator.h
@@ -32,7 +32,7 @@ namespace iguana {
 
       /// Set this validator's output directory
       /// @param output_dir the output directory
-      void SetOutputDirectory(std::string output_dir);
+      void SetOutputDirectory(std::string_view output_dir);
 
       /// Get this validator's output directory
       /// @returns an `optional`, which is set if the output directory is defined

--- a/src/iguana/algorithms/Validator.h
+++ b/src/iguana/algorithms/Validator.h
@@ -20,7 +20,7 @@ namespace iguana {
     public:
 
       /// @param name the unique name for a derived class instance
-      Validator(const std::string name = "validator")
+      Validator(std::string_view name = "validator")
           : Algorithm(name)
           , m_output_dir("")
       {}

--- a/src/iguana/services/ConfigFileReader.cc
+++ b/src/iguana/services/ConfigFileReader.cc
@@ -15,15 +15,15 @@ namespace iguana {
     return IGUANA_ETC;
   }
 
-  void ConfigFileReader::AddDirectory(std::string_view dir)
+  void ConfigFileReader::AddDirectory(std::string const& dir)
   {
     if(dir == "")
       return; // handle unset directory name
     m_log->Trace("Add directory {}", dir);
-    m_directories.push_front(dir.data());
+    m_directories.push_front(dir);
   }
 
-  void ConfigFileReader::AddFile(std::string_view name)
+  void ConfigFileReader::AddFile(std::string const& name)
   {
     if(name == "")
       return; // handle unset file name
@@ -43,7 +43,7 @@ namespace iguana {
     }
   }
 
-  std::string ConfigFileReader::FindFile(std::string_view name)
+  std::string ConfigFileReader::FindFile(std::string const& name)
   {
     if(name == "")
       return ""; // handle unset file name
@@ -52,10 +52,10 @@ namespace iguana {
     auto found_local = std::filesystem::exists(name);
     m_log->Trace("  - ./{}", found_local ? " - FOUND" : "");
     if(found_local)
-      return name.data();
+      return name;
     // then search each entry of `m_directories`
     for(auto const& dir : m_directories) {
-      std::string filename = dir + "/" + name.data();
+      std::string filename = dir + "/" + name;
       auto found           = std::filesystem::exists(filename);
       m_log->Trace("  - {}{}", dir, found ? " - FOUND" : "");
       if(found)
@@ -77,11 +77,11 @@ namespace iguana {
 
   std::string ConfigFileReader::ConvertAlgoNameToConfigName(std::string_view algo_name, std::string_view ext)
   {
-    std::string result        = algo_name.data();
+    std::string result        = std::string(algo_name);
     std::string::size_type it = 0;
     while((it = result.find("::", it)) != std::string::npos)
       result.replace(it, 2, "/");
-    return "algorithms/" + result + "." + ext.data();
+    return "algorithms/" + result + "." + std::string(ext);
   }
 
 }

--- a/src/iguana/services/ConfigFileReader.cc
+++ b/src/iguana/services/ConfigFileReader.cc
@@ -3,7 +3,7 @@
 
 namespace iguana {
 
-  ConfigFileReader::ConfigFileReader(const std::string name)
+  ConfigFileReader::ConfigFileReader(std::string_view name)
       : Object(name)
   {
     // add config files from installation prefix
@@ -15,15 +15,15 @@ namespace iguana {
     return IGUANA_ETC;
   }
 
-  void ConfigFileReader::AddDirectory(const std::string dir)
+  void ConfigFileReader::AddDirectory(std::string_view dir)
   {
     if(dir == "")
       return; // handle unset directory name
     m_log->Trace("Add directory {}", dir);
-    m_directories.push_front(dir);
+    m_directories.push_front(dir.data());
   }
 
-  void ConfigFileReader::AddFile(const std::string name)
+  void ConfigFileReader::AddFile(std::string_view name)
   {
     if(name == "")
       return; // handle unset file name
@@ -43,7 +43,7 @@ namespace iguana {
     }
   }
 
-  std::string ConfigFileReader::FindFile(const std::string name)
+  std::string ConfigFileReader::FindFile(std::string_view name)
   {
     if(name == "")
       return ""; // handle unset file name
@@ -52,10 +52,10 @@ namespace iguana {
     auto found_local = std::filesystem::exists(name);
     m_log->Trace("  - ./{}", found_local ? " - FOUND" : "");
     if(found_local)
-      return name;
+      return name.data();
     // then search each entry of `m_directories`
     for(auto const& dir : m_directories) {
-      std::string filename = dir + "/" + name;
+      std::string filename = dir + "/" + name.data();
       auto found           = std::filesystem::exists(filename);
       m_log->Trace("  - {}{}", dir, found ? " - FOUND" : "");
       if(found)
@@ -67,7 +67,7 @@ namespace iguana {
     throw std::runtime_error("configuration file not found");
   }
 
-  std::string ConfigFileReader::DirName(const std::string name)
+  std::string ConfigFileReader::DirName(std::string_view name)
   {
     auto result = std::filesystem::path{name}.parent_path().string();
     if(result == "")
@@ -75,13 +75,13 @@ namespace iguana {
     return result;
   }
 
-  std::string ConfigFileReader::ConvertAlgoNameToConfigName(const std::string algo_name, const std::string ext)
+  std::string ConfigFileReader::ConvertAlgoNameToConfigName(std::string_view algo_name, std::string_view ext)
   {
-    std::string result        = algo_name;
+    std::string result        = algo_name.data();
     std::string::size_type it = 0;
     while((it = result.find("::", it)) != std::string::npos)
       result.replace(it, 2, "/");
-    return "algorithms/" + result + "." + ext;
+    return "algorithms/" + result + "." + ext.data();
   }
 
 }

--- a/src/iguana/services/ConfigFileReader.h
+++ b/src/iguana/services/ConfigFileReader.h
@@ -12,7 +12,7 @@ namespace iguana {
     public:
 
       /// @param name the name of this configuration file handler
-      ConfigFileReader(const std::string name = "config");
+      ConfigFileReader(std::string_view name = "config");
 
       /// Get the config files' _fixed_ installation prefix
       /// @return the absolute path to the installed configuration file directory
@@ -20,11 +20,11 @@ namespace iguana {
 
       /// Add a directory to the configuration files' search paths.
       /// @param dir the directory, which may be relative or absolute
-      void AddDirectory(const std::string dir);
+      void AddDirectory(std::string_view dir);
 
       /// Add a configuration file to be parsed
       /// @param name the name of the file
-      void AddFile(const std::string name);
+      void AddFile(std::string_view name);
 
       /// Print the list of directories (search path)
       /// @param level the log level
@@ -37,19 +37,19 @@ namespace iguana {
       /// - the common installation prefix
       /// @param name the configuration file name (with or without a directory)
       /// @return the found configuration file (with the directory)
-      std::string FindFile(const std::string name);
+      std::string FindFile(std::string_view name);
 
       /// Return the directory containing a file, by stripping the last
       /// component of a file name, similarly to the `dirname` command.
       /// @param name the file name
       /// @return the parent directory name
-      static std::string DirName(const std::string name);
+      static std::string DirName(std::string_view name);
 
       /// Convert a full algorithm name to its corresponding default config file name
       /// @param algo_name the algorithm name
       /// @param ext the file extension
       /// @return the config file name
-      static std::string ConvertAlgoNameToConfigName(const std::string algo_name, const std::string ext = "yaml");
+      static std::string ConvertAlgoNameToConfigName(std::string_view algo_name, std::string_view ext = "yaml");
 
     protected:
 

--- a/src/iguana/services/ConfigFileReader.h
+++ b/src/iguana/services/ConfigFileReader.h
@@ -20,11 +20,11 @@ namespace iguana {
 
       /// Add a directory to the configuration files' search paths.
       /// @param dir the directory, which may be relative or absolute
-      void AddDirectory(std::string_view dir);
+      void AddDirectory(std::string const& dir);
 
       /// Add a configuration file to be parsed
       /// @param name the name of the file
-      void AddFile(std::string_view name);
+      void AddFile(std::string const& name);
 
       /// Print the list of directories (search path)
       /// @param level the log level
@@ -37,7 +37,7 @@ namespace iguana {
       /// - the common installation prefix
       /// @param name the configuration file name (with or without a directory)
       /// @return the found configuration file (with the directory)
-      std::string FindFile(std::string_view name);
+      std::string FindFile(std::string const& name);
 
       /// Return the directory containing a file, by stripping the last
       /// component of a file name, similarly to the `dirname` command.

--- a/src/iguana/services/Logger.cc
+++ b/src/iguana/services/Logger.cc
@@ -58,7 +58,7 @@ namespace iguana {
 
   std::string Logger::Header(std::string_view message, int const width)
   {
-    return fmt::format("{:=^{}}", " " + message + " ", width);
+    return fmt::format("{:=^{}}", fmt::format(" {} ", message), width);
   }
 
 }

--- a/src/iguana/services/Logger.cc
+++ b/src/iguana/services/Logger.cc
@@ -2,7 +2,7 @@
 
 namespace iguana {
 
-  Logger::Logger(const std::string name, const Level lev, bool const enable_style)
+  Logger::Logger(std::string_view name, const Level lev, bool const enable_style)
       : m_name(name)
       , m_enable_style(enable_style)
   {
@@ -17,7 +17,7 @@ namespace iguana {
     SetLevel(lev);
   }
 
-  void Logger::SetLevel(const std::string lev)
+  void Logger::SetLevel(std::string_view lev)
   {
     for(auto& [lev_i, lev_n] : m_level_names) {
       if(lev == lev_n) {
@@ -56,7 +56,7 @@ namespace iguana {
     m_enable_style = false;
   }
 
-  std::string Logger::Header(const std::string message, int const width)
+  std::string Logger::Header(std::string_view message, int const width)
   {
     return fmt::format("{:=^{}}", " " + message + " ", width);
   }

--- a/src/iguana/services/Logger.h
+++ b/src/iguana/services/Logger.h
@@ -115,10 +115,9 @@ namespace iguana {
                 { return fmt::format("[{}]", fmt::styled(s, fmt::emphasis::bold)); };
               }
             }
-            std::string_view prefix = fmt::format("{} {} ", style(it->second), style(m_name));
             fmt::print(
                 lev >= warn ? stderr : stdout,
-                fmt::runtime(prefix + message + "\n"),
+                fmt::runtime(fmt::format("{} {} {}\n", style(it->second), style(m_name), message)),
                 vals...);
           }
           else {

--- a/src/iguana/services/Logger.h
+++ b/src/iguana/services/Logger.h
@@ -98,7 +98,6 @@ namespace iguana {
       {
         if(lev >= m_level) {
           if(auto it{m_level_names.find(lev)}; it != m_level_names.end()) {
-            std::string prefix;
             std::function<std::string(std::string)> style = [](std::string s)
             { return fmt::format("[{}]", s); };
             if(m_enable_style) {
@@ -116,10 +115,10 @@ namespace iguana {
                 { return fmt::format("[{}]", fmt::styled(s, fmt::emphasis::bold)); };
               }
             }
-            prefix = fmt::format("{} {} ", style(it->second), style(m_name));
+            std::string_view prefix = fmt::format("{} {} ", style(it->second), style(m_name));
             fmt::print(
                 lev >= warn ? stderr : stdout,
-                fmt::runtime(prefix + message.data() + "\n"),
+                fmt::runtime(prefix + message + "\n"),
                 vals...);
           }
           else {

--- a/src/iguana/services/Logger.h
+++ b/src/iguana/services/Logger.h
@@ -43,13 +43,13 @@ namespace iguana {
       /// @param name the name of this logger instance, which will be include in all of its printouts
       /// @param lev the log level
       /// @param enable_style if true, certain printouts will be styled with color and emphasis
-      Logger(const std::string name = "log", const Level lev = DEFAULT_LEVEL, bool const enable_style = true);
+      Logger(std::string_view name = "log", const Level lev = DEFAULT_LEVEL, bool const enable_style = true);
       ~Logger() {}
 
       /// Set the log level to this level. Log messages with a lower level will not be printed.
       /// @see `Logger::Level` for available levels.
       /// @param lev the log level name
-      void SetLevel(const std::string lev);
+      void SetLevel(std::string_view lev);
 
       /// Set the log level to this level. Log messages with a lower level will not be printed.
       /// @see `Logger::Level` for available levels.
@@ -70,23 +70,23 @@ namespace iguana {
       /// @param message the header message
       /// @param width the width of the header in number of characters
       /// @returns the header string
-      static std::string Header(const std::string message, int const width = 50);
+      static std::string Header(std::string_view message, int const width = 50);
 
       /// Printout a log message at the `trace` level @see `Logger::Print` for more details
       template <typename... VALUES>
-      void Trace(const std::string message, const VALUES... vals) const { Print(trace, message, vals...); }
+      void Trace(std::string_view message, const VALUES... vals) const { Print(trace, message, vals...); }
       /// Printout a log message at the `debug` level @see `Logger::Print` for more details
       template <typename... VALUES>
-      void Debug(const std::string message, const VALUES... vals) const { Print(debug, message, vals...); }
+      void Debug(std::string_view message, const VALUES... vals) const { Print(debug, message, vals...); }
       /// Printout a log message at the `info` level @see `Logger::Print` for more details
       template <typename... VALUES>
-      void Info(const std::string message, const VALUES... vals) const { Print(info, message, vals...); }
+      void Info(std::string_view message, const VALUES... vals) const { Print(info, message, vals...); }
       /// Printout a log message at the `warn` level @see `Logger::Print` for more details
       template <typename... VALUES>
-      void Warn(const std::string message, const VALUES... vals) const { Print(warn, message, vals...); }
+      void Warn(std::string_view message, const VALUES... vals) const { Print(warn, message, vals...); }
       /// Printout a log message at the `error` level @see `Logger::Print` for more details
       template <typename... VALUES>
-      void Error(const std::string message, const VALUES... vals) const { Print(error, message, vals...); }
+      void Error(std::string_view message, const VALUES... vals) const { Print(error, message, vals...); }
 
       /// Printout a log message at the specified level. The message will only print if `lev` is at least as high as the current level of
       /// this `Logger` instance, as set by `Logger::SetLevel`.
@@ -94,7 +94,7 @@ namespace iguana {
       /// @param message the message to print; this may be a format string, as in `fmt::format`
       /// @param vals values for the format string `message`
       template <typename... VALUES>
-      void Print(const Level lev, const std::string message, const VALUES... vals) const
+      void Print(const Level lev, std::string_view message, const VALUES... vals) const
       {
         if(lev >= m_level) {
           if(auto it{m_level_names.find(lev)}; it != m_level_names.end()) {
@@ -119,7 +119,7 @@ namespace iguana {
             prefix = fmt::format("{} {} ", style(it->second), style(m_name));
             fmt::print(
                 lev >= warn ? stderr : stdout,
-                fmt::runtime(prefix + message + "\n"),
+                fmt::runtime(prefix + message.data() + "\n"),
                 vals...);
           }
           else {

--- a/src/iguana/services/Object.cc
+++ b/src/iguana/services/Object.cc
@@ -2,7 +2,7 @@
 
 namespace iguana {
 
-  Object::Object(const std::string name)
+  Object::Object(std::string_view name)
       : m_name(name)
       , m_log(std::make_unique<Logger>(m_name))
   {}
@@ -12,7 +12,7 @@ namespace iguana {
     return m_log;
   }
 
-  void Object::SetName(const std::string name)
+  void Object::SetName(std::string_view name)
   {
     m_name        = name;
     m_log->m_name = name;
@@ -23,7 +23,7 @@ namespace iguana {
     return m_name;
   }
 
-  void Object::SetLogLevel(const std::string lev)
+  void Object::SetLogLevel(std::string_view lev)
   {
     m_log->SetLevel(lev);
   }

--- a/src/iguana/services/Object.h
+++ b/src/iguana/services/Object.h
@@ -14,7 +14,7 @@ namespace iguana {
     public:
 
       /// @param name the name of this object
-      Object(const std::string name = "");
+      Object(std::string_view name = "");
       ~Object() {}
 
       /// Get the logger
@@ -23,7 +23,7 @@ namespace iguana {
 
       /// Change the name of this object
       /// @param name the new name
-      void SetName(const std::string name);
+      void SetName(std::string_view name);
 
       /// Get the name of this object
       std::string GetName() const;
@@ -31,7 +31,7 @@ namespace iguana {
       /// Set the log level to this level. Log messages with a lower level will not be printed.
       /// @see `Logger::Level` for available levels.
       /// @param lev the log level name
-      void SetLogLevel(const std::string lev);
+      void SetLogLevel(std::string_view lev);
 
       /// Set the log level to this level. Log messages with a lower level will not be printed.
       /// @see `Logger::Level` for available levels.

--- a/src/iguana/services/YAMLReader.cc
+++ b/src/iguana/services/YAMLReader.cc
@@ -101,7 +101,7 @@ namespace iguana {
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename SCALAR>
-  YAMLReader::node_finder_t YAMLReader::InRange(std::string key, SCALAR val)
+  YAMLReader::node_finder_t YAMLReader::InRange(std::string const& key, SCALAR val)
   {
     return [this, key, val](YAML::Node node) -> YAML::Node
     {
@@ -128,8 +128,8 @@ namespace iguana {
       throw std::runtime_error("Failed `InRange`");
     };
   }
-  template YAMLReader::node_finder_t YAMLReader::InRange(std::string key, int val);
-  template YAMLReader::node_finder_t YAMLReader::InRange(std::string key, double val);
+  template YAMLReader::node_finder_t YAMLReader::InRange(std::string const& key, int val);
+  template YAMLReader::node_finder_t YAMLReader::InRange(std::string const& key, double val);
 
   ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/iguana/services/YAMLReader.h
+++ b/src/iguana/services/YAMLReader.h
@@ -28,7 +28,7 @@ namespace iguana {
       using node_path_t = std::deque<node_id_t>;
 
       /// @param name of this reader (for `Logger`)
-      YAMLReader(const std::string name = "config")
+      YAMLReader(std::string_view name = "config")
           : ConfigFileReader(name)
       {}
       ~YAMLReader() {}

--- a/src/iguana/services/YAMLReader.h
+++ b/src/iguana/services/YAMLReader.h
@@ -66,7 +66,7 @@ namespace iguana {
       /// @param val the scalar value to check
       /// @returns the search function
       template <typename SCALAR>
-      node_finder_t InRange(std::string key, SCALAR val);
+      node_finder_t InRange(std::string const& key, SCALAR val);
 
     private:
 


### PR DESCRIPTION
This change is done where it is reasonable. For cases where the string is used for `unordered_map` lookup or insertion, `std::string const&` is used instead; when we move to C++20, then we can use heterogeneous lookup instead.