### PR TITLE
ci: temporarly roll back to meson 1.3.2

### DIFF
--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -17,7 +17,7 @@ GENERAL_PACKAGE_LIST_LINUX=(
   which
   pkgconf
   ninja
-  # meson # FIXME: temporarly using pip for older version
+  # meson # FIXME: temporarly using ALA for older version
   gcovr           # for coverage
   python-pygments # for coverage report syntax colors
   llvm            # for `llvm-symbolizer`, for human-readable sanitizer results

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -17,7 +17,7 @@ GENERAL_PACKAGE_LIST_LINUX=(
   which
   pkgconf
   ninja
-  meson
+  # meson # FIXME: temporarly using pip for older version
   gcovr           # for coverage
   python-pygments # for coverage report syntax colors
   llvm            # for `llvm-symbolizer`, for human-readable sanitizer results
@@ -112,6 +112,10 @@ case $runner in
       esac
       info_pacman $pkg
     done
+    ### FIXME: install older meson version
+    python -m pip install meson==1.3.2
+    echo "MESON VERSION:"
+    meson --version
     ;;
 
   macos*)

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -7,7 +7,6 @@ set -e
 ##############################
 GENERAL_PACKAGE_LIST_LINUX=(
   python
-  python-pip
   gcc
   clang
   make
@@ -114,7 +113,7 @@ case $runner in
       info_pacman $pkg
     done
     ### FIXME: install older meson version
-    python -m pip install meson==1.3.2
+    pacman -U --noconfirm https://archive.archlinux.org/packages/m/meson/meson-1.3.2-1-any.pkg.tar.zst
     echo "MESON VERSION:"
     meson --version
     ;;

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -7,6 +7,7 @@ set -e
 ##############################
 GENERAL_PACKAGE_LIST_LINUX=(
   python
+  python-pip
   gcc
   clang
   make

--- a/src/iguana/tests/include/TestLogger.h
+++ b/src/iguana/tests/include/TestLogger.h
@@ -14,7 +14,7 @@ inline int TestLogger()
   logs.at(1).DisableStyle();
 
   // set non-existent level; should print errors
-  auto non_existent_level = static_cast<iguana::Logger::Level>(1000);
+  // auto non_existent_level = static_cast<iguana::Logger::Level>(1000); // unused, since UndefinedBehaviorSanitizer catches any usage of this
   // logs.at(0).SetLevel(non_existent_level); // UndefinedBehaviorSanitizer catches this
   logs.at(0).SetLevel("non_existent_level");
 
@@ -26,7 +26,7 @@ inline int TestLogger()
     log.Warn("warn is level {}", static_cast<int>(iguana::Logger::Level::warn));
     log.Error("error is level {}", static_cast<int>(iguana::Logger::Level::error));
     // test non-existent level
-    log.Print(non_existent_level, "print to non-existent log level {}", static_cast<int>(non_existent_level));
+    // log.Print(non_existent_level, "print to non-existent log level {}", static_cast<int>(non_existent_level)); // UndefinedBehaviorSanitizer catches this
     // test silence
     log.SetLevel("silent");
     log.Error("if this prints, 'silent' level failed");

--- a/src/iguana/tests/include/TestLogger.h
+++ b/src/iguana/tests/include/TestLogger.h
@@ -15,7 +15,7 @@ inline int TestLogger()
 
   // set non-existent level; should print errors
   auto non_existent_level = static_cast<iguana::Logger::Level>(1000);
-  logs.at(0).SetLevel(non_existent_level);
+  // logs.at(0).SetLevel(non_existent_level); // UndefinedBehaviorSanitizer catches this
   logs.at(0).SetLevel("non_existent_level");
 
   for(auto& log : logs) {


### PR DESCRIPTION
Use older `meson` while awaiting for new release to fix #135 (since failing `iguana` tests currently prevent webpage deployment...)