### PR TITLE
fix: add `hipo` to library rpaths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,12 +261,13 @@ jobs:
       - name: dump build log
         if: always()
         run: cat build-iguana/meson-logs/meson-log.txt
-      - name: readelf/otool iguana examples
+      - name: readelf/otool iguana objects
         if: ${{ matrix.binding_opts == '' }}
         run: |
           binaries=$(find iguana/bin -type f -name "iguana-example-*")
-          libraries=$(find iguana -type f -name "*.so")
-          for obj in $binaries $libraries; do
+          libraries_so=$(find iguana -type f -name "*.so")
+          libraries_dylib=$(find iguana -type f -name "*.dylib")
+          for obj in $binaries $libraries_so $libraries_dylib; do
             echo "[+++] READ $obj"
             if [ ${{ inputs.runner }} = "macos-latest" ]; then
               otool -l $obj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,9 @@ jobs:
         run: iguana/bin/iguana-example-00-basic${{ matrix.extension }} test_data.hipo ${{ env.num_events }}
       - name: test 01
         run: iguana/bin/iguana-example-01-bank-rows${{ matrix.extension }} test_data.hipo ${{ env.num_events }}
+      - name: test 02
+        if: ${{ matrix.build_id == 'cpp-gcc-release' }}
+        run: iguana/bin/iguana-example-02-config-files
 
   # test consumers
   #########################################################

--- a/meson.build
+++ b/meson.build
@@ -146,19 +146,16 @@ project_test_env.set(
 )
 
 # rpaths
-project_lib_rpath = [
-  hipo_dep.get_variable(pkgconfig: 'libdir'),
-  '$ORIGIN',
-]
-project_exe_rpath = [
-  hipo_dep.get_variable(pkgconfig: 'libdir')
-]
+# FIXME(darwin): not sure how to set multiple rpaths on darwin objects,
+# aside from running `install_name_tool -add_rpath` post-installation
+# or requiring macOS users to set `$DYLD_LIBRARY_PATH`;
+# luckily, darwin-built objects don't need the `iguana` library path
+# explictly included in the rpath, so the `if darwin` block just keeps
+# rpaths minimal. See https://github.com/mesonbuild/meson/issues/5760
+project_lib_rpath = [ hipo_dep.get_variable(pkgconfig: 'libdir') ]
+project_exe_rpath = [ hipo_dep.get_variable(pkgconfig: 'libdir') ]
 if host_machine.system() != 'darwin'
-  # FIXME(darwin): not sure how to set multiple rpaths on darwin executables,
-  # aside from running `install_name_tool -add_rpath` post-installation;
-  # luckily, darwin-built executables don't need the `iguana` library path
-  # explictly included in the rpath, so this `if` block just keeps
-  # `project_exe_rpath` minimal. See https://github.com/mesonbuild/meson/issues/5760
+  project_lib_rpath += '$ORIGIN'
   project_exe_rpath += '$ORIGIN' / '..' / get_option('libdir')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -115,7 +115,6 @@ if ROOT_dep.found()
 endif
 
 # general project vars
-project_lib_rpath = '$ORIGIN'
 project_inc       = include_directories('src')
 project_libs      = []
 project_deps      = declare_dependency(dependencies: [ fmt_dep, yamlcpp_dep, hipo_dep ] ) # do NOT include ROOT here
@@ -146,7 +145,11 @@ project_test_env.set(
   'suppressions=' + meson.project_source_root() / 'meson' / 'lsan.supp',
 )
 
-# executables' rpath
+# rpaths
+project_lib_rpath = [
+  hipo_dep.get_variable(pkgconfig: 'libdir'),
+  '$ORIGIN',
+]
 project_exe_rpath = [
   hipo_dep.get_variable(pkgconfig: 'libdir')
 ]

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -134,7 +134,7 @@ algo_lib = shared_library(
   link_with:           services_lib,
   link_args:           ROOT_dep_link_args,
   install:             true,
-  install_rpath:       project_lib_rpath,
+  install_rpath:       ':'.join(project_lib_rpath),
   build_rpath:         ROOT_dep_rpath,
 )
 install_headers(
@@ -153,7 +153,7 @@ vdor_lib = shared_library(
   link_with:           [ services_lib, algo_lib ],
   link_args:           ROOT_dep_link_args + ROOT_dep_link_args_for_validators,
   install:             true,
-  install_rpath:       project_lib_rpath,
+  install_rpath:       ':'.join(project_lib_rpath),
   build_rpath:         ROOT_dep_rpath,
 )
 install_headers(

--- a/src/iguana/services/meson.build
+++ b/src/iguana/services/meson.build
@@ -18,7 +18,7 @@ services_lib = shared_library(
   include_directories: project_inc,
   dependencies:        project_deps,
   install:             true,
-  install_rpath:       project_lib_rpath,
+  install_rpath:       ':'.join(project_lib_rpath),
 )
 project_libs += services_lib
 


### PR DESCRIPTION
Example 02 was complaining about missing `libhipo4`, even though `dependency(hipo4)` was included in its executable. The issue is actually upstream of the executable: `libhipo4`'s location was never put in `install_rpath` of the shared libraries.