### PR TITLE
fix(ci): only install `doxygen` when needed

### DIFF
--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -18,8 +18,6 @@ GENERAL_PACKAGE_LIST_LINUX=(
   pkgconf
   ninja
   # meson # FIXME: temporarly using ALA for older version
-  doxygen         # for documentation
-  graphviz        # for `dot` for documentation
   gcovr           # for coverage
   python-pygments # for coverage report syntax colors
   llvm            # for `llvm-symbolizer`, for human-readable sanitizer results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,7 +594,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install dependencies
-        run: .github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm doxygen graphviz
       - name: doxygen
         run: doxygen doc/Doxyfile
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/minver.yml
+++ b/.github/workflows/minver.yml
@@ -1,7 +1,6 @@
 name: MinVer # minimum required-version of dependencies on Linux
 
 on:
-  pull_request: # FIXME: delete this
   schedule:
     - cron: '15 7 * * 0' # Sundays at 0715Z
 

--- a/.github/workflows/minver.yml
+++ b/.github/workflows/minver.yml
@@ -1,6 +1,7 @@
 name: MinVer # minimum required-version of dependencies on Linux
 
 on:
+  pull_request: # FIXME: delete this
   schedule:
     - cron: '15 7 * * 0' # Sundays at 0715Z
 


### PR DESCRIPTION
Linux min-ver job fails since latest `doxygen` needs `fmt` 10.x; workaround by moving `doxygen` installation to job step.

Fix https://github.com/JeffersonLab/iguana/issues/160