### PR TITLE
test: limit the number of events for example tests

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -35,7 +35,7 @@ foreach example, info : example_sources
       example_exe,
       args: info.get(
         'test_args',
-        [ get_option('test_data_file'), get_option('test_num_events') ]
+        [ get_option('test_data_file'), '100' ] # don't run too many events, or meson test log will be huge
       ),
       env: project_test_env,
     )


### PR DESCRIPTION
If we process too many events in the example tests, the test log output file will be huge, since the examples are quite verbose by design. Users who want to run examples with more events may simply run the example executables (rather than `meson test`).