### PR TITLE
feat: make `SectorFinder` a creator algorithm and a prerequisite for `MomentumCorrection`

### DIFF
--- a/bind/python/iguana-example-00-basic.py
+++ b/bind/python/iguana-example-00-basic.py
@@ -22,6 +22,7 @@ banks  = reader.getBanks([
 
 seq = iguana.AlgorithmSequence('pyiguana')
 seq.Add('clas12::EventBuilderFilter')
+seq.Add('clas12::SectorFinder')
 seq.Add('clas12::MomentumCorrection')
 seq.PrintSequence()
 

--- a/examples/iguana-example-00-basic.cc
+++ b/examples/iguana-example-00-basic.cc
@@ -50,6 +50,7 @@ int main(int argc, char** argv)
   // iguana algorithm sequence
   iguana::AlgorithmSequence seq;
   seq.Add("clas12::EventBuilderFilter"); // filter by Event Builder PID
+  seq.Add("clas12::SectorFinder"); // get the sector for each particle
   seq.Add("clas12::MomentumCorrection"); // momentum corrections
 
   // set log levels

--- a/src/iguana/algorithms/clas12/MomentumCorrection.cc
+++ b/src/iguana/algorithms/clas12/MomentumCorrection.cc
@@ -8,24 +8,19 @@ namespace iguana::clas12 {
   void MomentumCorrection::Start(hipo::banklist& banks)
   {
     b_particle = GetBankIndex(banks, "REC::Particle");
+    b_sector   = GetBankIndex(banks, "REC::Particle::Sector");
     b_config   = GetBankIndex(banks, "RUN::config");
-
-    m_sector_finder = std::make_unique<SectorFinder>();
-    if(m_rows_only)
-      m_sector_finder->Start();
-    else
-      m_sector_finder->Start(banks);
   }
 
 
   void MomentumCorrection::Run(hipo::banklist& banks) const
   {
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
+    auto& sectorBank   = GetBank(banks, b_sector, "REC::Particle::Sector");
     auto& configBank   = GetBank(banks, b_config, "RUN::config");
     ShowBank(particleBank, Logger::Header("INPUT PARTICLES"));
 
     auto torus   = configBank.getFloat("torus", 0);
-    auto sectors = m_sector_finder->Find(banks);
 
     for(int row = 0; row < particleBank.getRows(); row++) {
 
@@ -33,7 +28,7 @@ namespace iguana::clas12 {
           particleBank.getFloat("px", row),
           particleBank.getFloat("py", row),
           particleBank.getFloat("pz", row),
-          sectors.at(row),
+          sectorBank.getInt("sector", row),
           particleBank.getInt("pid", row),
           torus);
       particleBank.putFloat("px", row, px);

--- a/src/iguana/algorithms/clas12/MomentumCorrection.h
+++ b/src/iguana/algorithms/clas12/MomentumCorrection.h
@@ -2,7 +2,6 @@
 
 #include "iguana/algorithms/Algorithm.h"
 #include "iguana/algorithms/TypeDefs.h"
-#include "iguana/algorithms/clas12/SectorFinder.h"
 
 namespace iguana::clas12 {
 
@@ -71,13 +70,10 @@ namespace iguana::clas12 {
 
     private:
 
-      /// `hipo::banklist` index for the particle bank
+      /// `hipo::banklist` indices
       hipo::banklist::size_type b_particle;
-      /// `hipo::banklist` index for the config bank
+      hipo::banklist::size_type b_sector;
       hipo::banklist::size_type b_config;
-
-      /// sector finder
-      std::unique_ptr<SectorFinder> m_sector_finder;
   };
 
 }

--- a/src/iguana/algorithms/clas12/MomentumCorrectionValidator.cc
+++ b/src/iguana/algorithms/clas12/MomentumCorrectionValidator.cc
@@ -12,16 +12,14 @@ namespace iguana::clas12 {
     // define the algorithm sequence
     m_algo_seq = std::make_unique<AlgorithmSequence>();
     m_algo_seq->Add("clas12::EventBuilderFilter");
+    m_algo_seq->Add("clas12::SectorFinder");
     m_algo_seq->Add("clas12::MomentumCorrection");
     m_algo_seq->SetOption<std::vector<int>>("clas12::EventBuilderFilter", "pids", u_pdg_list);
     m_algo_seq->Start(banks);
 
-    // define the sector finder
-    m_sector_finder = std::make_unique<SectorFinder>();
-    m_sector_finder->Start(banks);
-
     // get bank indices
     b_particle = GetBankIndex(banks, "REC::Particle");
+    b_sector   = GetBankIndex(banks, "REC::Particle::Sector");
 
     // set an output file
     auto output_dir = GetOutputDirectory();
@@ -55,6 +53,7 @@ namespace iguana::clas12 {
     // get the momenta before
     // FIXME: will need to refactor this once we have HIPO iterators
     auto& particle_bank = GetBank(banks, b_particle, "REC::Particle");
+    auto& sector_bank   = GetBank(banks, b_sector, "REC::Particle::Sector");
     std::vector<double> p_measured;
     for(int row = 0; row < particle_bank.getRows(); row++)
       p_measured.push_back(std::hypot(
@@ -65,9 +64,6 @@ namespace iguana::clas12 {
     // run the momentum corrections
     m_algo_seq->Run(banks);
 
-    // get the sectors
-    auto sectors = m_sector_finder->Find(banks);
-
     // lock the mutex, so we can mutate plots
     std::scoped_lock<std::mutex> lock(m_mutex);
 
@@ -75,7 +71,7 @@ namespace iguana::clas12 {
     for(int row = 0; row < particle_bank.getRows(); row++) {
 
       auto pdg    = particle_bank.getInt("pid", row);
-      auto sector = sectors.at(row);
+      auto sector = sector_bank.getInt("sector", row);
       if(pdg == -1)
         continue; // FIXME: will need to refactor this once we have HIPO iterators
 

--- a/src/iguana/algorithms/clas12/MomentumCorrectionValidator.h
+++ b/src/iguana/algorithms/clas12/MomentumCorrectionValidator.h
@@ -2,7 +2,6 @@
 
 #include "iguana/algorithms/TypeDefs.h"
 #include "iguana/algorithms/Validator.h"
-#include "iguana/algorithms/clas12/SectorFinder.h"
 
 #include <TCanvas.h>
 #include <TFile.h>
@@ -25,8 +24,7 @@ namespace iguana::clas12 {
     private:
 
       hipo::banklist::size_type b_particle;
-
-      std::unique_ptr<SectorFinder> m_sector_finder;
+      hipo::banklist::size_type b_sector;
 
       double const m_p_max       = 12.0;
       double const m_deltaP_max  = 1.0;

--- a/src/iguana/algorithms/clas12/SectorFinder.h
+++ b/src/iguana/algorithms/clas12/SectorFinder.h
@@ -25,11 +25,6 @@ namespace iguana::clas12 {
       void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
-      /// finds the sector for all rows in REC::Particle
-      /// @param banks the list of banks to process
-      /// @returns std::vector of sector numbers
-      std::vector<int> Find(hipo::banklist& banks) const;
-
       /// get sector from bank for a given pindex
       /// @param bank bank to get sector from
       /// @param pindex index in bank for which to get sector
@@ -44,7 +39,11 @@ namespace iguana::clas12 {
       hipo::banklist::size_type b_track;
       hipo::banklist::size_type b_scint;
       hipo::banklist::size_type b_user;
+      hipo::banklist::size_type b_result;
       bool userSpecifiedBank{false};
+
+      // `b_result` bank item indices
+      int i_sector;
 
       /// Configuration options
       std::string o_bankname;

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -16,7 +16,10 @@
 #       'needs_ROOT':   BOOLEAN,  # whether this validator needs ROOT or not (default=false)
 #     },
 #     'configs':        LIST_OF_ALGORITHM_CONFIG_FILES,
-#     'test_args':      DICTIONARY_FOR_TESTING_ARGS,  # if excluded, tests won't run for this algorithm
+#     'test_args': {    DICTIONARY_FOR_TESTING_ARGS,  # if excluded, tests won't run for this algorithm
+#       'banks':          LIST_OF_BANKS # only those that are needed to test this algorithm
+#       'prerequisites':  LIST_OF_PREREQUISITE_ALGORITHMS # those that are required to `Run` before this one
+#     },
 #   }
 #
 algo_dict = {
@@ -86,7 +89,10 @@ algo_dict = {
       'headers': [ 'clas12/MomentumCorrectionValidator.h' ],
       'needs_ROOT': true,
     },
-    'test_args': { 'banks': ['RUN::config', 'REC::Particle', 'REC::Calorimeter', 'REC::Track', 'REC::Scintillator'] },
+    'test_args': {
+      'banks': ['RUN::config', 'REC::Particle', 'REC::Calorimeter', 'REC::Track', 'REC::Scintillator'],
+      'prerequisites': ['clas12::SectorFinder'],
+    },
   },
   'physics::InclusiveKinematics': {
     'algorithm': {

--- a/src/iguana/tests/iguana-test.cc
+++ b/src/iguana/tests/iguana-test.cc
@@ -16,6 +16,7 @@ int main(int argc, char** argv)
   std::string output_dir = "";
   bool verbose           = false;
   std::vector<std::string> bank_names;
+  std::vector<std::string> prerequisite_algos;
 
   // get the command
   auto exe           = std::string(argv[0]);
@@ -72,7 +73,13 @@ int main(int argc, char** argv)
            fmt::print("    {:<20} you may add as many banks as you need (-b BANK1 -b BANK2 ...)\n", "");
            fmt::print("    {:<20} default: if you do not add any banks, ALL of them will be used\n", "");
          }},
-
+        {"p", [&]()
+         {
+           fmt::print("    {:<20} {}\n", "-p PREREQUISITE_ALGOS", "add a prerequisite algorithm");
+           fmt::print("    {:<20} these are the algorithms needed upstream of ALGORITHM\n", "");
+           fmt::print("    {:<20} this option is repeatable\n", "");
+           fmt::print("    {:<20} default: no prerequisites\n", "");
+         }},
         {"t", [&]()
          {
            fmt::print("    {:<20} {}\n", "-t TESTNUM", "test number");
@@ -87,7 +94,7 @@ int main(int argc, char** argv)
          }}};
     std::vector<std::string> available_options;
     if(command == "algorithm" || command == "unit") {
-      available_options = {"f", "n", "a-algo", "b"};
+      available_options = {"f", "n", "a-algo", "b", "p"};
     }
     else if(command == "validator") {
       available_options = {"f", "n", "a-vdor", "b", "o"};
@@ -119,7 +126,7 @@ int main(int argc, char** argv)
 
   // parse option arguments
   int opt;
-  while((opt = getopt(argc, argv, "hf:n:a:b:t:o:v|")) != -1) {
+  while((opt = getopt(argc, argv, "hf:n:a:b:p:t:o:v|")) != -1) {
     switch(opt) {
     case 'h':
       return UsageOptions(2);
@@ -134,6 +141,9 @@ int main(int argc, char** argv)
       break;
     case 'b':
       bank_names.push_back(std::string(optarg));
+      break;
+    case 'p':
+      prerequisite_algos.push_back(std::string(optarg));
       break;
     case 't':
       test_num = std::stoi(optarg);
@@ -166,13 +176,14 @@ int main(int argc, char** argv)
   fmt::print("  {:>20} = {}\n", "num_events", num_events);
   fmt::print("  {:>20} = {}\n", "algo_name", algo_name);
   fmt::print("  {:>20} = {}\n", "banks", fmt::join(bank_names, ", "));
+  fmt::print("  {:>20} = {}\n", "prerequisite_algos", fmt::join(prerequisite_algos, ", "));
   fmt::print("  {:>20} = {}\n", "test_num", test_num);
   fmt::print("  {:>20} = {}\n", "output_dir", output_dir);
   fmt::print("\n");
 
   // run test
   if(command == "algorithm" || command == "unit")
-    return TestAlgorithm(command, algo_name, bank_names, data_file, num_events, verbose);
+    return TestAlgorithm(command, algo_name, prerequisite_algos, bank_names, data_file, num_events, verbose);
   else if(command == "validator")
     return TestValidator(algo_name, bank_names, data_file, num_events, output_dir, verbose);
   else if(command == "config")

--- a/src/iguana/tests/include/TestAlgorithm.h
+++ b/src/iguana/tests/include/TestAlgorithm.h
@@ -6,6 +6,7 @@
 inline int TestAlgorithm(
     std::string command,
     std::string algo_name,
+    std::vector<std::string> prerequisite_algos,
     std::vector<std::string> bank_names,
     std::string data_file,
     int num_events,
@@ -31,6 +32,8 @@ inline int TestAlgorithm(
 
   // define the algorithm
   iguana::AlgorithmSequence seq;
+  for(auto const& prerequisite_algo : prerequisite_algos)
+    seq.Add(prerequisite_algo);
   seq.Add(algo_name);
   seq.SetName("TEST");
   seq.PrintSequence();

--- a/src/iguana/tests/meson.build
+++ b/src/iguana/tests/meson.build
@@ -18,10 +18,13 @@ if fs.is_file(get_option('test_data_file'))
   foreach name, info : algo_dict
     if info.has_key('test_args')
 
-      # get list of banks
-      bank_args = []
+      # get list of banks and prerequisite algorithms
+      extra_args = []
       foreach bank : info['test_args'].get('banks', [])
-        bank_args += ['-b', bank]
+        extra_args += ['-b', bank]
+      endforeach
+      foreach prerequisite : info['test_args'].get('prerequisites', [])
+        extra_args += ['-p', prerequisite]
       endforeach
 
       # test names cannot have colons
@@ -35,7 +38,7 @@ if fs.is_file(get_option('test_data_file'))
           '-f', get_option('test_data_file'),
           '-n', get_option('test_num_events'),
           '-a', name,
-        ] + bank_args
+        ] + extra_args
         test(
           'algorithm-' + test_name_algo,
           test_exe,


### PR DESCRIPTION
- `SectorFinder` now creates a new bank, with the sector for each particle
- since this is required for `MomentumCorrection`, the tests are now aware of prerequisite algorithms