### PR TITLE
fix(ci): revert to latest `meson` version

### DIFF
--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -19,6 +19,7 @@ GENERAL_PACKAGE_LIST_LINUX=(
   pkgconf
   ninja
   meson
+  lcov            # for coverage
   gcovr           # for coverage
   python-pygments # for coverage report syntax colors
   llvm            # for `llvm-symbolizer`, for human-readable sanitizer results

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -19,10 +19,11 @@ GENERAL_PACKAGE_LIST_LINUX=(
   pkgconf
   ninja
   meson
-  lcov            # for coverage
-  gcovr           # for coverage
-  python-pygments # for coverage report syntax colors
-  llvm            # for `llvm-symbolizer`, for human-readable sanitizer results
+  llvm  # for `llvm-symbolizer`, for human-readable sanitizer results
+  ### coverage
+  python-colorlog
+  python-pygments
+  gcovr
   ### ROOT dependencies
   binutils
   libx11

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -18,7 +18,7 @@ GENERAL_PACKAGE_LIST_LINUX=(
   which
   pkgconf
   ninja
-  # meson # FIXME: temporarly using ALA for older version
+  meson
   gcovr           # for coverage
   python-pygments # for coverage report syntax colors
   llvm            # for `llvm-symbolizer`, for human-readable sanitizer results
@@ -114,10 +114,6 @@ case $runner in
       esac
       info_pacman $pkg
     done
-    ### FIXME: install older meson version
-    pacman -U --noconfirm https://archive.archlinux.org/packages/m/meson/meson-1.3.2-1-any.pkg.tar.zst
-    echo "MESON VERSION:"
-    meson --version
     ;;
 
   macos*)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,7 @@ jobs:
         if: ${{ matrix.id == 'coverage' }}
         run: |
           ninja -C iguana_build coverage-html
+          ninja -C iguana_build coverage-text
           mv iguana_build/meson-logs/coveragereport coverage-report
           echo '### Coverage Report' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
       - name: coverage
         if: ${{ matrix.id == 'coverage' }}
         run: |
-          ninja -C iguana_build coverage
+          ninja -C iguana_build coverage-html
           mv iguana_build/meson-logs/coveragereport coverage-report
           echo '### Coverage Report' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Using Arch Linux Archive's `meson` version 1.3.2 is now failing (#181, #182). Let's revert to using the latest `meson` version now, and live with the sanitizer env var issue #135 until a new `meson` version is released.