### PR TITLE
fix: omit empty variables from pkg-config file generation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -172,12 +172,18 @@ if get_option('bind_python')
 endif
 
 # generate pkg-config file
+project_pkg_vars_nonempty = []
+foreach var : project_pkg_vars
+  if not var.endswith('=') # remove empty variable values
+    project_pkg_vars_nonempty += var
+  endif
+endforeach
 pkg.generate(
   name:        meson.project_name(),
   description: project_description,
   libraries:   project_libs,
   requires:    [ fmt_dep, yamlcpp_dep, hipo_dep ], # pkg-config dependencies only
-  variables:   project_pkg_vars,
+  variables:   project_pkg_vars_nonempty,
 )
 
 # build examples


### PR DESCRIPTION
Fixes the following `meson` error:
```
ERROR: pkgconfig.generate keyword argument "variables" empty variable value
```