### PR TITLE
ci: run validators on all available events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,11 @@ jobs:
       ### build
       - name: meson setup
         run: |
+          if [ "${{ matrix.id }}" = "cpp" ]; then
+            validate_all="true" # 'cpp' job will upload validator artifacts, so use all statistics
+          else
+            validate_all="false"
+          fi
           meson setup iguana_build iguana_src           \
             --prefix=$(pwd)/iguana                      \
             --cmake-prefix-path=$(pwd)/root             \
@@ -283,6 +288,7 @@ jobs:
             -Dtest_data_file=$(pwd)/test_data.hipo      \
             -Dtest_num_events=${{ env.num_events }}     \
             -Dtest_output_dir=$(pwd)/validation_results \
+            -Dtest_validator_all_stats=${validate_all}  \
             ${{ matrix.opts }}
       - name: dump build options
         run: meson configure iguana_build --no-pager

--- a/meson.options
+++ b/meson.options
@@ -6,10 +6,10 @@ option('bind_python',  type: 'boolean', value: false, description: 'Install Pyth
 option('install_examples', type: 'boolean', value: false, description: 'Install examples')
 
 # test options: control how tests are run
-option('test_data_file',  type: 'string', value: '',   description: 'Sample HIPO file for testing. Must be an absolute path. If unspecified, tests that need them are not built')
-option('test_num_events', type: 'string', value: '10', description: 'Number of events from `test_data_file` to test')
-option('test_output_dir', type: 'string', value: '',   description: 'Output directory for tests. Must be an absolute path. If unspecified, tests will still run, but will not produce output files.')
-option('test_validator_all_stats', type: boolean, value: false, description: 'If true, use all statistics for validators, rather than `test_num_events`)
+option('test_data_file',           type: 'string',  value: '',    description: 'Sample HIPO file for testing. Must be an absolute path. If unspecified, tests that need them are not built')
+option('test_num_events',          type: 'string',  value: '10',  description: 'Number of events from `test_data_file` to test')
+option('test_output_dir',          type: 'string',  value: '',    description: 'Output directory for tests. Must be an absolute path. If unspecified, tests will still run, but will not produce output files.')
+option('test_validator_all_stats', type: 'boolean', value: false, description: 'If true, use all statistics for validators, rather than `test_num_events`')
 
 # expert options: the defaults should be reasonable for a local installation; different values may be preferred for installation in common areas
 option('z_install_envfile',     type: 'boolean', value: true,  description: 'Install a sourceable environment variable file')

--- a/meson.options
+++ b/meson.options
@@ -9,6 +9,7 @@ option('install_examples', type: 'boolean', value: false, description: 'Install 
 option('test_data_file',  type: 'string', value: '',   description: 'Sample HIPO file for testing. Must be an absolute path. If unspecified, tests that need them are not built')
 option('test_num_events', type: 'string', value: '10', description: 'Number of events from `test_data_file` to test')
 option('test_output_dir', type: 'string', value: '',   description: 'Output directory for tests. Must be an absolute path. If unspecified, tests will still run, but will not produce output files.')
+option('test_validator_all_stats', type: boolean, value: false, description: 'If true, use all statistics for validators, rather than `test_num_events`)
 
 # expert options: the defaults should be reasonable for a local installation; different values may be preferred for installation in common areas
 option('z_install_envfile',     type: 'boolean', value: true,  description: 'Install a sourceable environment variable file')

--- a/src/iguana/tests/meson.build
+++ b/src/iguana/tests/meson.build
@@ -61,7 +61,7 @@ if fs.is_file(get_option('test_data_file'))
           test_args = [
             'validator',
             '-f', get_option('test_data_file'),
-            '-n', '0',
+            '-n', get_option('test_validator_all_stats') ? '0' : get_option('test_num_events'),
             '-a', name + 'Validator',
           ]
           if get_option('test_output_dir') != ''
@@ -74,6 +74,7 @@ if fs.is_file(get_option('test_data_file'))
             test_exe,
             args: test_args,
             env: project_test_env,
+            timeout: get_option('test_validator_all_stats') ? 0 : 120,
           )
         endif
       endif

--- a/src/iguana/tests/meson.build
+++ b/src/iguana/tests/meson.build
@@ -61,7 +61,7 @@ if fs.is_file(get_option('test_data_file'))
           test_args = [
             'validator',
             '-f', get_option('test_data_file'),
-            '-n', get_option('test_num_events'),
+            '-n', '0',
             '-a', name + 'Validator',
           ]
           if get_option('test_output_dir') != ''


### PR DESCRIPTION
We want the validator artifacts (validation plots) to be full statistics, so add build option `test_validator_all_stats` to do so. It's default is `false`, so that `meson test` is fast by default; validator devs should set it to `true` if they want to see full stats locally (or just leave that job to the CI).