### PR TITLE
fix: support `csh` as well as `tcsh`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,6 +199,7 @@ if get_option('z_install_envfile')
   configure_file(
     input:         'meson' / 'this_iguana.sh.in',
     output:        'this_iguana.sh',
+    install:       true,
     install_dir:   get_option('bindir'),
     configuration: {
       'ld_path': host_machine.system() != 'darwin' ? 'LD_LIBRARY_PATH' : 'DYLD_LIBRARY_PATH',
@@ -206,11 +207,15 @@ if get_option('z_install_envfile')
       'libdir':  get_option('libdir'),
     },
   )
-  install_data(
-    'meson' / 'this_iguana.tcsh.in',
-    rename:      'this_iguana.tcsh',
-    install_dir: get_option('bindir'),
-  )
+  foreach shell : ['csh', 'tcsh']
+    configure_file(
+      input:         'meson' / 'this_iguana.csh.in',
+      output:        'this_iguana.' + shell,
+      install:       true,
+      install_dir:   get_option('bindir'),
+      configuration: {'shell': shell},
+    )
+  endforeach
 endif
 
 # generate modulefile

--- a/meson.build
+++ b/meson.build
@@ -195,24 +195,23 @@ if get_option('install_examples')
 endif
 
 # install environment setup files
-configure_file(
-  input:         'meson' / 'this_iguana.sh.in',
-  output:        'this_iguana.sh',
-  install:       get_option('z_install_envfile'),
-  install_dir:   get_option('bindir'),
-  configuration: {
-    'ld_path': host_machine.system() != 'darwin' ? 'LD_LIBRARY_PATH' : 'DYLD_LIBRARY_PATH',
-    'python':  get_option('bind_python') ? 'true' : 'false',
-    'libdir':  get_option('libdir'),
-  },
-)
-configure_file(
-  input:         'meson' / 'this_iguana.tcsh.in',
-  output:        'this_iguana.tcsh',
-  install:       get_option('z_install_envfile'),
-  install_dir:   get_option('bindir'),
-  configuration: {},
-)
+if get_option('z_install_envfile')
+  configure_file(
+    input:         'meson' / 'this_iguana.sh.in',
+    output:        'this_iguana.sh',
+    install_dir:   get_option('bindir'),
+    configuration: {
+      'ld_path': host_machine.system() != 'darwin' ? 'LD_LIBRARY_PATH' : 'DYLD_LIBRARY_PATH',
+      'python':  get_option('bind_python') ? 'true' : 'false',
+      'libdir':  get_option('libdir'),
+    },
+  )
+  install_data(
+    'meson' / 'this_iguana.tcsh.in',
+    rename:      'this_iguana.tcsh',
+    install_dir: get_option('bindir'),
+  )
+endif
 
 # generate modulefile
 if(get_option('z_generate_modulefile'))

--- a/meson/this_iguana.csh.in
+++ b/meson/this_iguana.csh.in
@@ -1,8 +1,8 @@
-#!/usr/bin/env tcsh
+#!/usr/bin/env @shell@
 set user_command = ($_)
-set IGUANA_TCSH_ENV_FILE=`readlink -f $user_command[2]`
+set IGUANA_CSH_ENV_FILE=`readlink -f $user_command[2]`
 unset user_command
-echo 'Creating `tcsh` sub-shell for iguana environment.'
+echo 'Creating `@shell@` sub-shell for iguana environment.'
 echo ''
 echo 'NOTE: using iguana with this sub-shell is not well-tested; please report'
 echo '      any problems or consider using `bash` or `zsh` and sourcing'
@@ -13,6 +13,6 @@ echo '      should be set to enable merging, e.g. in your `~/.cshrc` file:'
 echo '        set history=10000'
 echo '        set savehist=(10000 merge)'
 echo ''
-bash -c "source `dirname $IGUANA_TCSH_ENV_FILE`/this_iguana.sh && exec tcsh"
-echo 'Exited iguana `tcsh` sub-shell.'
-unset IGUANA_TCSH_ENV_FILE
+bash -c "source `dirname $IGUANA_CSH_ENV_FILE`/this_iguana.sh && exec @shell@"
+echo 'Exited iguana `@shell@` sub-shell.'
+unset IGUANA_CSH_ENV_FILE


### PR DESCRIPTION
Although many users use `tcsh` as the default shell, some may prefer `csh`. Since `csh` and `tcsh` iguana environments create a sub-shell, this fix provides the ability to spawn the preferred sub-shell, `tcsh` or `csh`.

Also removes a `meson` warning about empty configuration.