### PR TITLE
ci: treat warnings as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,7 @@ jobs:
             --prefix=$(pwd)/iguana                      \
             --cmake-prefix-path=$(pwd)/root             \
             --pkg-config-path=$(pwd)/hipo/lib/pkgconfig \
+            -Dwerror=true                               \
             -Dinstall_examples=true                     \
             -Dtest_data_file=$(pwd)/test_data.hipo      \
             -Dtest_num_events=${{ env.num_events }}     \


### PR DESCRIPTION
To prevent warnings (which can be real issues) from slipping through the cracks, build with `-werror`, so CI jobs fail if there are warnings. This is not the default build option, so that developers can still make test builds if there are warnings.