### PR TITLE
fix: treat warnings as errors and fix them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,7 @@ jobs:
             --prefix=$(pwd)/iguana                      \
             --cmake-prefix-path=$(pwd)/root             \
             --pkg-config-path=$(pwd)/hipo/lib/pkgconfig \
+            -Dwerror=true                               \
             -Dinstall_examples=true                     \
             -Dtest_data_file=$(pwd)/test_data.hipo      \
             -Dtest_num_events=${{ env.num_events }}     \

--- a/src/iguana/algorithms/Bindings.cc
+++ b/src/iguana/algorithms/Bindings.cc
@@ -142,7 +142,7 @@ namespace iguana::bindings {
 
   void iguana_getconfiginstallationprefix_(char* out)
   {
-    sprintf(out, "%s", ConfigFileReader::GetConfigInstallationPrefix().c_str());
+    strcpy(out, ConfigFileReader::GetConfigInstallationPrefix().c_str());
   }
   }
 }

--- a/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.cc
@@ -386,7 +386,7 @@ namespace iguana::clas12 {
 
     // Default to RGA inbending pass1 if no match found
     m_log->Warn("Run Number {} with pass {} has no matching PhotonGBT model...Defaulting to RGA inbending pass1...", runnum, o_pass);
-    return [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); };
+    return [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); };
   }
 
   void PhotonGBTFilter::Stop()

--- a/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.h
@@ -127,22 +127,22 @@ namespace iguana::clas12 {
     
       /// Map for the GBT Models to use depending on pass and run number
       const std::map<std::tuple<int, int, int>, std::function<double(std::vector<float> const &)>> modelMap = {
-            {{5032, 5332, 1}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Fall2018 RGA Inbending
-            {{5032, 5332, 2}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Fall2018 RGA Inbending
-            {{5333, 5666, 1}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_outbending_pass1(data); }}, // Fall2018 RGA Outbending
-            {{5333, 5666, 2}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_outbending_pass2(data); }}, // Fall2018 RGA Outbending
-            {{6616, 6783, 1}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Spring2019 RGA Inbending
-            {{6616, 6783, 2}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Spring2019 RGA Inbending
-            {{6156, 6603, 1}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Spring2019 RGB Inbending
-            {{6156, 6603, 2}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Spring2019 RGB Inbending
-            {{11093, 11283, 1}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_outbending_pass1(data); }}, // Fall2019 RGB Outbending
-            {{11093, 11283, 2}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_outbending_pass2(data); }}, // Fall2019 RGB Outbending
-            {{11284, 11300, 1}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Fall2019 RGB BAND Inbending
-            {{11284, 11300, 2}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Fall2019 RGB BAND Inbending
-            {{11323, 11571, 1}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Spring2020 RGB Inbending
-            {{11323, 11571, 2}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Spring2020 RGB Inbending
-            {{16042, 16772, 1}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGC_Summer2022_pass1(data); }}, // Summer2022 RGC Inbending
-            {{16042, 16772, 2}, [this](std::vector<float> const &data) { return ApplyCatboostModel_RGC_Summer2022_pass1(data); }} // Summer2022 RGC Inbending (no pass2 currently)
+            {{5032, 5332, 1}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Fall2018 RGA Inbending
+            {{5032, 5332, 2}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Fall2018 RGA Inbending
+            {{5333, 5666, 1}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_outbending_pass1(data); }}, // Fall2018 RGA Outbending
+            {{5333, 5666, 2}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_outbending_pass2(data); }}, // Fall2018 RGA Outbending
+            {{6616, 6783, 1}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Spring2019 RGA Inbending
+            {{6616, 6783, 2}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Spring2019 RGA Inbending
+            {{6156, 6603, 1}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Spring2019 RGB Inbending
+            {{6156, 6603, 2}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Spring2019 RGB Inbending
+            {{11093, 11283, 1}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_outbending_pass1(data); }}, // Fall2019 RGB Outbending
+            {{11093, 11283, 2}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_outbending_pass2(data); }}, // Fall2019 RGB Outbending
+            {{11284, 11300, 1}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Fall2019 RGB BAND Inbending
+            {{11284, 11300, 2}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Fall2019 RGB BAND Inbending
+            {{11323, 11571, 1}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass1(data); }}, // Spring2020 RGB Inbending
+            {{11323, 11571, 2}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGA_inbending_pass2(data); }}, // Spring2020 RGB Inbending
+            {{16042, 16772, 1}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGC_Summer2022_pass1(data); }}, // Summer2022 RGC Inbending
+            {{16042, 16772, 2}, [](std::vector<float> const &data) { return ApplyCatboostModel_RGC_Summer2022_pass1(data); }} // Summer2022 RGC Inbending (no pass2 currently)
        };
   };
     


### PR DESCRIPTION
To prevent warnings (which can be real issues) from slipping through the cracks, build with `-werror`, so CI jobs fail if there are warnings. This is not the default build option, so that developers can still make test builds if there are warnings.

Fixed the following warnings:
- unused lambda captures in `PhotonGBTFilter`
- `sprintf` deprecation