### PR TITLE
Sector Finder: Support for charged & neutral particles, added action function and validator

### DIFF
--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
@@ -149,8 +149,8 @@ namespace iguana::clas12 {
   void SectorFinder::GetListsSectorPindex(hipo::bank const& bank, std::vector<int>& sectors, std::vector<int>& pindices) const
   {
     for(auto const& row : bank.getRowList()) {
-      //check that we'e only using FD detectors
-      //ie have "sectors" in CND
+      //check that we're only using FD detectors
+      //eg have "sectors" in CND which we don't want to add here
       int det=bank.getInt("detector",row);
       std::set<int>::iterator it = listFDDets.find(det);
       if (it != listFDDets.end()) {

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -27,6 +27,38 @@ namespace iguana::clas12 {
 
       /// @action_function{vector creator} get sector from list of `sectors` and `pindices` from same bank, ordered in same way;
       /// _nb_: this is done instead of finding the `pindex` in the bank directly, to have an action function
+      /// 
+      /// **Example:**
+      /// ```cpp
+      ///
+      /// //... Initialise algorithms & banks ... 
+      ///
+      /// //For each event, do:
+      ///
+      /// std::vector<int> sectors;
+      /// std::vector<int> pindices
+      ///
+      /// //bank is a hipo::bank object from which we want to get the sectors
+      /// //for example the bank object related to REC::Calorimeter
+      /// for(auto const& row : bank.getRowList()) {
+      ///
+      ///     int det=bank.getInt("detector",row);
+      ///
+      ///     //NB: you should check you read from an FD detector
+      ///     // eg det 7 is the ECAL
+      ///     if(det==7){
+      ///       sectors.push_back(bank.getInt("sector", row));
+      ///       pindices.push_back(bank.getInt("pindex", row));
+      ///     }
+      /// }
+      ///
+      /// //partbank is a Hipo::Bank object related to REC::Particle
+      /// //algo_sector_finder is the iguana::clas12::SectorFinder object
+      /// for(auto const& row : partbank.getRowList()) {
+      ///     int sector = algo_sector_finder.GetSector(sectors, pindices, row);
+      /// }
+      /// ```
+      ///
       /// @param sectors list of sectors in a bank
       /// @param pindices list of pindices in a bank
       /// @param pindex index in `REC::Particle` bank for which to get sector

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -59,8 +59,8 @@ namespace iguana::clas12 {
       /// }
       /// ```
       ///
-      /// @param sectors list of sectors in a bank
-      /// @param pindices list of pindices in a bank
+      /// @param sectors list of sectors in a detector bank
+      /// @param pindices list of pindices in a detector bank
       /// @param pindex index in `REC::Particle` bank for which to get sector
       /// @returns sector for `pindex` in list, -1 if `pindex` not in inputted list
       int GetSector(std::vector<int> const& sectors, std::vector<int> const& pindices, int const pindex) const;

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -54,10 +54,14 @@ namespace iguana::clas12 {
 
       // `b_result` bank item indices
       int i_sector;
+      int i_pindex;
 
       /// Configuration options
       std::string o_bankname_charged;
       std::string o_bankname_uncharged;
+
+      //only want sectors from FD detectors
+      std::set<int> const listFDDets{6,7,12,15,16,18};
   };
 
 }

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -25,7 +25,7 @@ namespace iguana::clas12 {
       void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
-      /// @action_function{vector creator} get sector from list of `sectors` and `pindices` from same bank, ordered in same way;
+      /// @action_function{vector creator} for a given particle with index `pindex`, get its sector from a detector bank's list of `sectors` and `pindices` (both must be ordered in the same way);
       /// _nb_: this is done instead of finding the `pindex` in the bank directly, to have an action function
       /// 
       /// **Example:**

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -31,6 +31,15 @@ namespace iguana::clas12 {
       /// @returns sector for pindex in bank
       int GetSector(hipo::bank const& bank, int const pindex) const;
 
+      /// set sector to output bank for a row in particle bank
+      /// useful to avoid duplicating code for charged/uncharged particles
+      /// @param banks list of banks used by the algorithm
+      /// @param resultBank bank in which we add the sector
+      /// @param row row in REC::Particle::Sector to fill
+      /// @param userSpecifiedBank whether or not to get sector from user specified bank
+      /// @param b_user link to user specified bank
+      void setSector(hipo::banklist& banks,hipo::bank& resultBank, int row, bool userSpecifiedBank, hipo::banklist::size_type b_user) const;
+
     private:
 
       /// `hipo::banklist` index for the particle bank
@@ -38,15 +47,18 @@ namespace iguana::clas12 {
       hipo::banklist::size_type b_calorimeter;
       hipo::banklist::size_type b_track;
       hipo::banklist::size_type b_scint;
-      hipo::banklist::size_type b_user;
+      hipo::banklist::size_type b_user_charged;
+      hipo::banklist::size_type b_user_uncharged;
       hipo::banklist::size_type b_result;
-      bool userSpecifiedBank{false};
+      bool userSpecifiedBank_charged{false};
+      bool userSpecifiedBank_uncharged{true};
 
       // `b_result` bank item indices
       int i_sector;
 
       /// Configuration options
-      std::string o_bankname;
+      std::string o_bankname_charged;
+      std::string o_bankname_uncharged;
   };
 
 }

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -25,20 +25,19 @@ namespace iguana::clas12 {
       void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
-      /// get sector from bank for a given pindex
-      /// @param bank bank to get sector from
-      /// @param pindex index in bank for which to get sector
-      /// @returns sector for pindex in bank
-      int GetSector(hipo::bank const& bank, int const pindex) const;
+      /// action function, get sector from list of sectors and pindices from same bank, ordered in same way
+      /// nb: this is done instead of finding the pindex in the bank directly to have an action function
+      /// @param sectors list of sectors in a bank
+      /// @param pindices list of pindices in a bank
+      /// @param pindex index in rec::particle bank for which to get sector
+      /// @returns sector for pindex in list, -1 if pindex not in inputted list
+      int GetSector(std::vector<int> const& sectors, std::vector<int> const& pindices, int const pindex) const;
 
-      /// set sector to output bank for a row in particle bank
-      /// useful to avoid duplicating code for charged/uncharged particles
-      /// @param banks list of banks used by the algorithm
-      /// @param resultBank bank in which we add the sector
-      /// @param row row in REC::Particle::Sector to fill
-      /// @param userSpecifiedBank whether or not to get sector from user specified bank
-      /// @param b_user link to user specified bank
-      void setSector(hipo::banklist& banks,hipo::bank& resultBank, int row, bool userSpecifiedBank, hipo::banklist::size_type b_user) const;
+      /// fill lists of sectors and pindices present in the input bank
+      /// @param bank bank from which to get lists of sectors and pindices
+      /// @param sectors list to fill with sectors in the bank
+      /// @param pindices list to fill with pindices in the bank
+      void GetListsSectorPindex(hipo::bank const& bank, std::vector<int>& sectors, std::vector<int>& pindices) const;
 
     private:
 

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -52,7 +52,7 @@ namespace iguana::clas12 {
       ///     }
       /// }
       ///
-      /// //partbank is a Hipo::Bank object related to REC::Particle
+      /// //partbank is a hipo::bank object related to REC::Particle
       /// //algo_sector_finder is the iguana::clas12::SectorFinder object
       /// for(auto const& row : partbank.getRowList()) {
       ///     int sector = algo_sector_finder.GetSector(sectors, pindices, row);

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -25,12 +25,12 @@ namespace iguana::clas12 {
       void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
-      /// action function, get sector from list of sectors and pindices from same bank, ordered in same way
-      /// nb: this is done instead of finding the pindex in the bank directly to have an action function
+      /// @action_function{vector creator} get sector from list of `sectors` and `pindices` from same bank, ordered in same way;
+      /// _nb_: this is done instead of finding the `pindex` in the bank directly, to have an action function
       /// @param sectors list of sectors in a bank
       /// @param pindices list of pindices in a bank
-      /// @param pindex index in rec::particle bank for which to get sector
-      /// @returns sector for pindex in list, -1 if pindex not in inputted list
+      /// @param pindex index in `REC::Particle` bank for which to get sector
+      /// @returns sector for `pindex` in list, -1 if `pindex` not in inputted list
       int GetSector(std::vector<int> const& sectors, std::vector<int> const& pindices, int const pindex) const;
 
       /// fill lists of sectors and pindices present in the input bank

--- a/src/iguana/algorithms/clas12/SectorFinder/Config.yaml
+++ b/src/iguana/algorithms/clas12/SectorFinder/Config.yaml
@@ -1,5 +1,11 @@
 clas12::SectorFinder:
   # use the default banks
-  bank: default
+  # for both charged/uncharged particles
+  bank_charged: default
+  bank_uncharged: default
+  
   # or force finder to use a certain bank with eg:
-  #bank: REC::Calorimeter
+  #can have default for charged but not uncharged particles
+  #or vice versa
+  #bank_charged: default
+  #bank_uncharged: REC::Calorimeter

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
@@ -39,7 +39,7 @@ namespace iguana::clas12 {
         TString sector_title = Form("sector %d", sec);
         YvsX.push_back(new TH2D(
             "YvsX_" + particle_name + "_" + sector_name,
-            particle_title + " Calorimeter Hit Position, " + sector_title + ";X;Y",
+            particle_title + " Calorimeter Hit Position, " + sector_title + ";X [cm];Y [cm]",
             50, -500, 500,
             50, -500, 500));
       }

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
@@ -39,7 +39,7 @@ namespace iguana::clas12 {
         TString sector_title = Form("sector %d", sec);
         YvsX.push_back(new TH2D(
             "YvsX_" + particle_name + "_" + sector_name,
-            particle_title + "Calorimeter Hit Position, " + sector_title + ";X;Y",
+            particle_title + " Calorimeter Hit Position, " + sector_title + ";X;Y",
             50, -500, 500,
             50, -500, 500));
       }

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
@@ -1,0 +1,113 @@
+#include "Validator.h"
+
+#include <TProfile.h>
+#include <TStyle.h>
+
+namespace iguana::clas12 {
+
+  REGISTER_IGUANA_VALIDATOR(SectorFinderValidator);
+
+  void SectorFinderValidator::Start(hipo::banklist& banks)
+  {
+    // define the algorithm sequence
+    m_algo_seq = std::make_unique<AlgorithmSequence>();
+    m_algo_seq->Add("clas12::EventBuilderFilter");
+    m_algo_seq->Add("clas12::SectorFinder");
+    m_algo_seq->SetOption<std::vector<int>>("clas12::EventBuilderFilter", "pids", u_pdg_list);
+    m_algo_seq->Start(banks);
+
+
+    b_particle = GetBankIndex(banks, "REC::Particle");
+    b_cal = GetBankIndex(banks, "REC::Calorimeter");
+    b_sector   = GetBankIndex(banks, "REC::Particle::Sector");
+
+    // set an output file
+    auto output_dir = GetOutputDirectory();
+    if(output_dir) {
+      m_output_file_basename = output_dir.value() + "/sector_finder";
+      m_output_file          = new TFile(m_output_file_basename + ".root", "RECREATE");
+    }
+
+    // define plots
+    gStyle->SetOptStat(0);
+    for(auto const& pdg : u_pdg_list) {
+      std::vector<TH2D*> YvsX;
+      TString particle_name  = particle::name.at(particle::PDG(pdg));
+      TString particle_title = particle::title.at(particle::PDG(pdg));
+      for(int sec = 1; sec <= 6; sec++) {
+        TString sector_name  = Form("sec%d", sec);
+        TString sector_title = Form("sector %d", sec);
+        YvsX.push_back(new TH2D(
+            "YvsX_" + particle_name + "_" + sector_name,
+            particle_title + "Calorimeter Hit Position, " + sector_title + ";X;Y",
+            50, -500, 500,
+            50, -500, 500));
+      }
+      u_YvsX.insert({pdg, YvsX});
+    }
+  }
+
+  void SectorFinderValidator::Run(hipo::banklist& banks) const
+  {
+    // get the momenta before
+    auto& particle_bank = GetBank(banks, b_particle, "REC::Particle");
+    auto& sector_bank   = GetBank(banks, b_sector, "REC::Particle::Sector");
+    auto& cal_bank = GetBank(banks, b_cal, "REC::Calorimeter");
+
+    // run the momentum corrections
+    m_algo_seq->Run(banks);
+
+    // lock the mutex, so we can mutate plots
+    std::scoped_lock<std::mutex> lock(m_mutex);
+    // fill the plots
+    for(auto const& row : particle_bank.getRowList()) {
+
+      auto pdg    = particle_bank.getInt("pid", row);
+      auto sector = sector_bank.getInt("sector", row);
+
+      double x=0,y=0;
+      for(auto const& rowcal : cal_bank.getRowList()){
+        if(cal_bank.getInt("pindex", rowcal)==row){
+          x=cal_bank.getFloat("x", rowcal);
+          y=cal_bank.getFloat("y", rowcal);
+        }
+      }
+
+      // skip central particle, or unknown sector
+      if(sector == 0)
+        continue;
+      //std::cout<<pdg<<" "<<sector-1<<" "<<row<<std::endl;
+      u_YvsX.at(pdg).at(sector - 1)->Fill(x, y);
+    }
+  }
+
+
+  void SectorFinderValidator::Stop()
+  {
+    if(GetOutputDirectory()) {
+      for(auto const& [pdg, plots] : u_YvsX) {
+        int n_cols        = 3;
+        int n_rows        = 2;
+        TString canv_name = Form("canv%d", pdg);
+        auto canv         = new TCanvas(canv_name, canv_name, n_cols * 800, n_rows * 600);
+        canv->Divide(n_cols, n_rows);
+        int pad_num = 0;
+        for(auto const& plot : plots) {
+          auto pad = canv->GetPad(++pad_num);
+          pad->cd();
+          pad->SetGrid(1, 1);
+          pad->SetLogz();
+          pad->SetLeftMargin(0.12);
+          pad->SetRightMargin(0.12);
+          pad->SetBottomMargin(0.12);
+          plot->Draw("colz");
+        }
+        canv->SaveAs(m_output_file_basename + "_" + std::to_string(pdg) + ".png");
+      }
+      m_output_file->Write();
+      m_log->Info("Wrote output file {}", m_output_file->GetName());
+      m_output_file->Close();
+    }
+  }
+
+}

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
@@ -14,6 +14,8 @@ namespace iguana::clas12 {
     m_algo_seq->Add("clas12::EventBuilderFilter");
     m_algo_seq->Add("clas12::SectorFinder");
     m_algo_seq->SetOption<std::vector<int>>("clas12::EventBuilderFilter", "pids", u_pdg_list);
+    m_algo_seq->SetOption<std::string>("clas12::SectorFinder", "bank_charged", "REC::Track");
+    m_algo_seq->SetOption<std::string>("clas12::SectorFinder", "bank_uncharged", "default");
     m_algo_seq->Start(banks);
 
 
@@ -96,7 +98,6 @@ namespace iguana::clas12 {
           auto pad = canv->GetPad(++pad_num);
           pad->cd();
           pad->SetGrid(1, 1);
-          pad->SetLogz();
           pad->SetLeftMargin(0.12);
           pad->SetRightMargin(0.12);
           pad->SetBottomMargin(0.12);

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
@@ -99,7 +99,7 @@ namespace iguana::clas12 {
       // skip central particle, or unknown sector
       if(sector == 0)
         continue;
-      m_log->Trace("Filling SectorFinder Validator, {} pdg {} sector {} pindex {}", pdg, sector, row);
+      m_log->Trace("Filling SectorFinder Validator, pdg {} sector {} pindex {}", pdg, sector, row);
       u_YvsX.at(pdg).at(sector - 1)->Fill(x, y);
     }
 

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "iguana/algorithms/TypeDefs.h"
+#include "iguana/algorithms/Validator.h"
+
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TH2.h>
+
+namespace iguana::clas12 {
+
+  /// @brief `iguana::clas12::SectorFinder` validator
+  class SectorFinderValidator : public Validator
+  {
+
+      DEFINE_IGUANA_VALIDATOR(SectorFinderValidator, clas12::SectorFinderValidator)
+
+    public:
+
+      void Start(hipo::banklist& banks) override;
+      void Run(hipo::banklist& banks) const override;
+      void Stop() override;
+
+    private:
+
+      hipo::banklist::size_type b_particle;
+      hipo::banklist::size_type b_sector;
+      hipo::banklist::size_type b_cal;
+
+      std::vector<int> const u_pdg_list = {
+          particle::PDG::electron,
+          particle::PDG::photon,};
+
+      TString m_output_file_basename;
+      TFile* m_output_file;
+      mutable std::unordered_map<int, std::vector<TH2D*>> u_YvsX;
+  };
+
+}

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.h
@@ -6,6 +6,7 @@
 #include <TCanvas.h>
 #include <TFile.h>
 #include <TH2.h>
+#include <TH1.h>
 
 namespace iguana::clas12 {
 
@@ -34,6 +35,7 @@ namespace iguana::clas12 {
       TString m_output_file_basename;
       TFile* m_output_file;
       mutable std::unordered_map<int, std::vector<TH2D*>> u_YvsX;
+      TH1D* u_IsInFD;
   };
 
 }

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -61,7 +61,7 @@ algo_dict += [
   {
     'name': 'clas12::SectorFinder',
     'has_c_bindings': false,
-    'has_validator': false,
+    'has_validator': true,
     'test_args': { 'banks': ['REC::Particle', 'REC::Calorimeter', 'REC::Track', 'REC::Scintillator'] },
   },
   {


### PR DESCRIPTION
Before this pull request the config file was set up to take the same bank to find sector for charged and uncharged particles. This is problematic because the natural choice for charged particles (DC) is different from neutrals (calorimeters). SectorFinder also needed an action function and a validator

This pulls request introduces:

- Different banks for charged and neutral particles in config yaml. Choice is given to use default for one or both of charged/neutrals. Also fixed a bug due to certain banks containing non FD detectors, now only look at FD detectors.
- Add pindex entry to output bank to avoid confusion due to filtering of REC::Particle bank.
- Introduce a vector action function which finds the sector for a given pindex from a vector of sectors and pindices taken from some bank.
- Introduce a validator. This produces plots of the per sector X/Y calorimeter position for e- and photons. It is then trivial to see that the sector finding works as the X/Y positions are all in the right sectors. See below.


![image](https://github.com/JeffersonLab/iguana/assets/58739511/5060e51d-f803-435d-bf67-ba0fca56d662)
