### PR TITLE
ZVertexFilter: Only cut on FD and CD particles

### DIFF
--- a/examples/iguana_ex_fortran_01_action_functions.f
+++ b/examples/iguana_ex_fortran_01_action_functions.f
@@ -193,8 +193,8 @@ c       - the AND with the z-vertex filter is the final filter, `accept`
           call iguana_clas12_eventbuilderfilter_filter(
      &      algo_eb_filter, pid(i), accept(i))
           call iguana_clas12_zvertexfilter_filter(
-     &      algo_vz_filter, vz(i), pid(i), accept(i))
-          print *, '  i = ', i, '  pid = ', pid(i), ' vz = ', vz(i),
+     &      algo_vz_filter, vz(i), pid(i), stat(i), accept(i))
+          print *, '  i = ', i, '  pid = ', pid(i), '  status = ', stat(i), ' vz = ', vz(i),
      &      '  =>  accept = ', accept(i)
         enddo
 

--- a/examples/iguana_ex_fortran_01_action_functions.f
+++ b/examples/iguana_ex_fortran_01_action_functions.f
@@ -194,8 +194,8 @@ c       - the AND with the z-vertex filter is the final filter, `accept`
      &      algo_eb_filter, pid(i), accept(i))
           call iguana_clas12_zvertexfilter_filter(
      &      algo_vz_filter, vz(i), pid(i), stat(i), accept(i))
-          print *, '  i = ', i, '  pid = ', pid(i), '  status = ', stat(i), ' vz = ', vz(i),
-     &      '  =>  accept = ', accept(i)
+          print *, '  i = ', i, '  pid = ', pid(i), ' vz = ', vz(i),
+     &      '  status = ', stat(i), '  =>  accept = ', accept(i)
         enddo
 
 c       get sector number

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.cc
@@ -38,8 +38,9 @@ namespace iguana::clas12 {
     particleBank.getMutableRowList().filter([this](auto bank, auto row) {
         auto zvertex = bank.getFloat("vz", row);
         auto pid = bank.getInt("pid", row);
-        auto accept  = Filter(zvertex,pid);
-        m_log->Debug("input vz {} pid {} -- accept = {}", zvertex, pid, accept);
+        auto status = bank.getInt("status", row);
+        auto accept  = Filter(zvertex,pid,status);
+        m_log->Debug("input vz {} pid {} status {} -- accept = {}", zvertex, pid, status, accept);
         return accept ? 1 : 0;
         });
 
@@ -47,10 +48,11 @@ namespace iguana::clas12 {
     ShowBank(particleBank, Logger::Header("OUTPUT PARTICLES"));
   }
 
-  bool ZVertexFilter::Filter(double const zvertex, int pid) const
+  bool ZVertexFilter::Filter(double const zvertex, int pid, int status) const
   {
     //only apply filter if particle pid is in list of pids
-    if(o_pids.find(pid) != o_pids.end()) {
+    //and particles not in FT (ie FD or CD)
+    if(o_pids.find(pid) != o_pids.end() && abs(status)>=2000) {
       return zvertex > GetZcutLower() && zvertex < GetZcutUpper();
     } else {
       return true;

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.cc
@@ -38,7 +38,7 @@ namespace iguana::clas12 {
     particleBank.getMutableRowList().filter([this](auto bank, auto row) {
         auto zvertex = bank.getFloat("vz", row);
         auto pid = bank.getInt("pid", row);
-        auto status = bank.getInt("status", row);
+        auto status = bank.getShort("status", row);
         auto accept  = Filter(zvertex,pid,status);
         m_log->Debug("input vz {} pid {} status {} -- accept = {}", zvertex, pid, status, accept);
         return accept ? 1 : 0;

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.h
@@ -25,8 +25,8 @@ namespace iguana::clas12 {
       void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
-      /// @action_function{scalar filter} checks if the Z Vertex is within specified bounds if pid is one for which the filter should be applied to
-      /// cuts applied to particles in FD or CD (ie not in FT)
+      /// @action_function{scalar filter} checks if the Z Vertex is within specified bounds if pid is one for which the filter should be applied to.;
+      /// Cuts applied to particles in FD or CD (ie not in FT).
       /// @param zvertex the particle Z Vertex to check
       /// @param pid the particle pid
       /// @param status particle status used to check particle is not in FT

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.h
@@ -26,10 +26,12 @@ namespace iguana::clas12 {
       void Stop() override;
 
       /// @action_function{scalar filter} checks if the Z Vertex is within specified bounds if pid is one for which the filter should be applied to
+      /// cuts applied to particles in FD or CD (ie not in FT)
       /// @param zvertex the particle Z Vertex to check
       /// @param pid the particle pid
+      /// @param status particle status used to check particle is not in FT
       /// @returns `true` if `zvertex` is within specified bounds
-      bool Filter(double const zvertex, int pid) const;
+      bool Filter(double const zvertex, int pid, int status) const;
 
       /// @returns the current run number
       int GetRunNum() const;

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Bindings.cc
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Bindings.cc
@@ -8,10 +8,11 @@ namespace iguana::bindings {
   /// @param [in] algo_idx the algorithm index
   /// @param [in] vz
   /// @param [in] pid
+  /// @param [in] status
   /// @param [in,out] out the return value
-  void iguana_clas12_zvertexfilter_filter_(algo_idx_t* algo_idx, float* vz, int* pid, bool* out)
+  void iguana_clas12_zvertexfilter_filter_(algo_idx_t* algo_idx, float* vz, int* pid, int* status, bool* out)
   {
-    *out = *out && dynamic_cast<clas12::ZVertexFilter*>(iguana_get_algo_(algo_idx))->Filter(*vz, *pid);
+    *out = *out && dynamic_cast<clas12::ZVertexFilter*>(iguana_get_algo_(algo_idx))->Filter(*vz, *pid, *status);
   }
   }
 }

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Validator.cc
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Validator.cc
@@ -60,7 +60,7 @@ namespace iguana::clas12 {
     for(auto const& row : particle_bank.getRowList()) {
       double vz = particle_bank.getFloat("vz", row);
       int pdg = particle_bank.getInt("pid", row);
-      int status = particle_bank.getInt("status", row);
+      int status = particle_bank.getShort("status", row);
       auto it = u_zvertexplots.find(pdg);
       //check if pdg is amongs those that we want to plot
       if (it != u_zvertexplots.end() && abs(status)>=2000) {
@@ -75,7 +75,7 @@ namespace iguana::clas12 {
     for(auto const& row : particle_bank.getRowList()) {
       double vz = particle_bank.getFloat("vz", row);
       int pdg = particle_bank.getInt("pid", row);
-      int status = particle_bank.getInt("status", row);
+      int status = particle_bank.getShort("status", row);
       auto it = u_zvertexplots.find(pdg);
       //check if pdg is amongs those that we want to plot
       if (it != u_zvertexplots.end() && abs(status)>=2000) {

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Validator.cc
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Validator.cc
@@ -60,9 +60,10 @@ namespace iguana::clas12 {
     for(auto const& row : particle_bank.getRowList()) {
       double vz = particle_bank.getFloat("vz", row);
       int pdg = particle_bank.getInt("pid", row);
+      int status = particle_bank.getInt("status", row);
       auto it = u_zvertexplots.find(pdg);
       //check if pdg is amongs those that we want to plot
-      if (it != u_zvertexplots.end()) {
+      if (it != u_zvertexplots.end() && abs(status)>=2000) {
         u_zvertexplots.at(pdg).at(0)->Fill(vz);
       }
     }
@@ -74,9 +75,10 @@ namespace iguana::clas12 {
     for(auto const& row : particle_bank.getRowList()) {
       double vz = particle_bank.getFloat("vz", row);
       int pdg = particle_bank.getInt("pid", row);
+      int status = particle_bank.getInt("status", row);
       auto it = u_zvertexplots.find(pdg);
       //check if pdg is amongs those that we want to plot
-      if (it != u_zvertexplots.end()) {
+      if (it != u_zvertexplots.end() && abs(status)>=2000) {
         u_zvertexplots.at(pdg).at(1)->Fill(vz);
       }
     }


### PR DESCRIPTION
There is no z-vertex position from the FT, z vertex cut shouldn't be applied to electrons in the FT.

Fix is to require abs( status )>=2000 ie a particle is in FD or CD. Validator now only plots particles in FD or CD.