### PR TITLE
fix(ci): brew errors `Broken pipe @ io_writev`

### DIFF
--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -91,7 +91,9 @@ info_pacman() {
 }
 
 info_homebrew() {
-  echo "| \`$1\` | $(brew info $1 | head -n1) |" >> $summary_file
+  brew info $1 > info.tmp
+  echo "| \`$1\` | $(head -n1 info.tmp) |" >> $summary_file
+  rm info.tmp
 }
 
 #############################################
@@ -127,6 +129,7 @@ case $runner in
     for pkg in ${GENERAL_PACKAGE_LIST_MACOS[@]} ${IGUANA_PACKAGE_LIST_MACOS[@]}; do
       echo "[+] INSTALLING PACKAGE $pkg"
       brew install $pkg
+      echo "[+] dump version number to summary"
       info_homebrew $pkg
     done
     ### link homebrew's gcc, for gfortran

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -128,7 +128,7 @@ case $runner in
     ### install the latest version of all packages
     for pkg in ${GENERAL_PACKAGE_LIST_MACOS[@]} ${IGUANA_PACKAGE_LIST_MACOS[@]}; do
       echo "[+] INSTALLING PACKAGE $pkg"
-      brew install $pkg
+      brew install --quiet $pkg
       echo "[+] dump version number to summary"
       info_homebrew $pkg
     done


### PR DESCRIPTION
Fix the 56 broken pipe errors, coming from a `brew` command:
```
[+] INSTALLING PACKAGE tree
==> Downloading https://ghcr.io/v2/homebrew/core/tree/manifests/2.1.2
==> Fetching tree
==> Downloading https://ghcr.io/v2/homebrew/core/tree/blobs/sha256:0fdd34e46049ad22f376d1a38e9ab0a546c8d73c2069a8facc871c9457bf23d8
==> Pouring tree--2.1.2.arm64_sonoma.bottle.tar.gz
🍺  /opt/homebrew/Cellar/tree/2.1.2: 9 files, 181.6KB
Error: Broken pipe @ io_writev - <STDOUT>
Error: Broken pipe @ io_writev - <STDOUT>
```