### PR TITLE
fix(ci): no need for meson argument `--cmake-prefix-path` since we already set `$CMAKE_PREFIX_PATH`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,6 @@ jobs:
           fi
           meson setup iguana_build iguana_src           \
             --prefix=$(pwd)/iguana                      \
-            --cmake-prefix-path=$(pwd)/root             \
             --pkg-config-path=$(pwd)/hipo/lib/pkgconfig \
             -Dwerror=true                               \
             -Dinstall_examples=true                     \


### PR DESCRIPTION
No need to tell `meson` how to consume ROOT _twice_.