### PR TITLE
fix: add FD cut for pre-filter photons in `PhotonGBTFilter` validator

### DIFF
--- a/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.h
@@ -37,7 +37,12 @@ namespace iguana::clas12 {
       void Start(hipo::banklist& banks) override;
       void Run(hipo::banklist& banks) const override;
       void Stop() override;   
-      
+
+      /// **Method**: Applies forward detector cut using REC::Particle Theta
+      /// @param theta lab angle of the particle with respect to the beam direction (radians)
+      /// @returns `true` if the particle's theta is within the forward detector coverage, `false` otherwise
+      bool ForwardDetectorFilter(float const theta) const;
+
     private:
       
       struct calo_row_data {
@@ -67,13 +72,7 @@ namespace iguana::clas12 {
       /// @param theta lab angle of the photon with respect to the beam direction (radians)
       /// @returns `true` if the photon passes the pid purity cuts, `false` otherwise
       bool PidPurityPhotonFilter(float const E, float const Epcal, float const theta) const;
-      
-      
-      /// **Method**: Applies forward detector cut using REC::Particle Theta
-      /// @param theta lab angle of the particle with respect to the beam direction (radians)
-      /// @returns `true` if the particle's theta is within the forward detector coverage, `false` otherwise
-      bool ForwardDetectorFilter(float const theta) const;
-      
+
       /// **Action function**: Classifies the photon for a given event as signal or background
       /// @param particleBank the REC::Particle hipo bank
       /// @param caloBank the REC::Calorimeter hipo bank

--- a/src/iguana/algorithms/clas12/PhotonGBTFilter/Validator.cc
+++ b/src/iguana/algorithms/clas12/PhotonGBTFilter/Validator.cc
@@ -1,4 +1,5 @@
 #include "Validator.h"
+#include "Algorithm.h"
 namespace iguana::clas12 {
 
   REGISTER_IGUANA_VALIDATOR(PhotonGBTFilterValidator);
@@ -39,7 +40,8 @@ namespace iguana::clas12 {
         float pz = particle_bank.getFloat("pz",row);
         float E  = std::hypot(px,py,pz);
         ROOT::Math::PxPyPzEVector phot(px,py,pz,E);
-        photons.push_back(phot);
+        if(m_algo_seq->Get<PhotonGBTFilter>("clas12::PhotonGBTFilter")->ForwardDetectorFilter(phot.Theta()))
+          photons.push_back(phot);
     }
 
     // run the photon filter


### PR DESCRIPTION
This is the last fix we need for #244. `PhotonGBTFilter` already applies this cut, so the validator needs to also apply this cut to the unfiltered photons.