### PR TITLE
fix: test minimum and latest ROOT versions

### DIFF
--- a/.github/download-ROOT-source.rb
+++ b/.github/download-ROOT-source.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+# download the ROOT source code
+
+if ARGV.empty?
+  $stderr.puts "USAGE: #{$0} [tag]"
+  exit 2
+end
+TAG  = ARGV.first
+REPO = 'root-project/ROOT'
+
+info = Hash.new
+case TAG
+when 'latest'
+  info = {
+    :api_url   => "https://api.github.com/repos/#{REPO}/releases/latest",
+    :jq_filter => '.tarball_url',
+  }
+else
+  info = {
+    :api_url   => "https://api.github.com/repos/#{REPO}/tags",
+    :jq_filter => ".[] | select (.name==\"#{TAG}\") | .tarball_url",
+  }
+end
+
+api_args = [
+  '--silent',
+  '-L',
+  '-H "Accept: application/vnd.github+json"',
+  '-H "X-GitHub-Api-Version: 2022-11-28"',
+  info[:api_url],
+]
+cmd = "curl #{api_args.join ' '} | jq -r '#{info[:jq_filter]}'"
+puts """API call:
+#{'='*82}
+#{cmd}
+#{'='*82}"""
+
+error = Proc.new do |msg|
+  $stderr.puts "ERROR: #{msg}"
+  exit 1
+end
+
+payload = `#{cmd}`
+error.call 'GitHub API call failure' unless $?.success?
+error.call "GitHub API call returned empty string, perhaps tag '#{TAG}' does not exist?" if payload.empty?
+url = payload.chomp
+puts "TARBALL URL = #{url}"
+
+puts "Downloading ROOT version '#{TAG}'..."
+exec "wget -nv --no-check-certificate --output-document root.tar.gz #{url}"

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -34,6 +34,7 @@ GENERAL_PACKAGE_LIST_LINUX=(
   libxext
   openssl
   gsl
+  davix
 )
 IGUANA_PACKAGE_LIST_LINUX=(
   fmt

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -17,6 +17,7 @@ GENERAL_PACKAGE_LIST_LINUX=(
   wget
   git
   which
+  jq
   pkgconf
   ninja
   meson

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,7 @@ jobs:
           echo '| Dependency | Version |' >> $GITHUB_STEP_SUMMARY
           echo '| --- | --- |' >> $GITHUB_STEP_SUMMARY
           echo "| \`hipo\` | ${{ env.hipo_ref }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`root\` | $(root --version |& head -n1) |" >> $GITHUB_STEP_SUMMARY
           cat pkg_summary.md >> $GITHUB_STEP_SUMMARY
       ### build
       - name: meson setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
           echo '| Dependency | Version |' >> $GITHUB_STEP_SUMMARY
           echo '| --- | --- |' >> $GITHUB_STEP_SUMMARY
           echo "| \`hipo\` | ${{ env.hipo_ref }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`root\` | $(root --version |& head -n1) |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`root\` | $(root --version 2>&1 | head -n1) |" >> $GITHUB_STEP_SUMMARY
           cat pkg_summary.md >> $GITHUB_STEP_SUMMARY
       ### build
       - name: meson setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,11 @@ jobs:
       - name: download ROOT source code
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
-          srcURL=$(iguana_src/meson/minimum-version.sh root src)
-          echo "[+] DOWNLOADING ROOT SOURCE CODE FROM: $srcURL"
-          wget -nv --no-check-certificate $srcURL
+          ver=latest
+          if [ "${{ inputs.verset }}" = "minver" ]; then
+            ver=$(iguana_src/meson/minimum-version.sh root tag)
+          fi
+          iguana_src/.github/download-ROOT-source.rb $ver
           tar xf $(ls -t *.gz | head -n1)
           ls -t
           mv -v $(ls -td root-* | head -n1) root_src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,12 @@ jobs:
       - name: key
         id: key
         run: |
-          root_version=$(iguana_src/meson/minimum-version.sh root src | sed 's;.*/;;' | sed 's;\.tar\.gz;;')
-          echo key=root---${{ inputs.id }}---${root_version}---$(date +%Y-week%U) >> $GITHUB_OUTPUT
+          ver=latest
+          if [ "${{ inputs.verset }}" = "minver" ]; then
+            ver=$(iguana_src/meson/minimum-version.sh root tag)
+          fi
+          echo ver=$ver >> $GITHUB_OUTPUT
+          echo key=root---${{ inputs.id }}---${ver}---$(date +%Y-week%U) >> $GITHUB_OUTPUT
       - uses: actions/cache/restore@v4
         id: cache
         with:
@@ -108,11 +112,7 @@ jobs:
       - name: download ROOT source code
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
-          ver=latest
-          if [ "${{ inputs.verset }}" = "minver" ]; then
-            ver=$(iguana_src/meson/minimum-version.sh root tag)
-          fi
-          iguana_src/.github/download-ROOT-source.rb $ver
+          iguana_src/.github/download-ROOT-source.rb ${{ steps.key.outputs.ver }}
           tar xf $(ls -t *.gz | head -n1)
           ls -t
           mv -v $(ls -td root-* | head -n1) root_src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,9 @@ jobs:
       image: ${{ inputs.container }}
     outputs:
       key: ${{ steps.key.outputs.key }}
+      root_version: ${{ steps.key.outputs.root_version }}
     steps:
+      ### define key
       - name: checkout iguana
         uses: actions/checkout@v4
         with:
@@ -94,25 +96,24 @@ jobs:
       - name: key
         id: key
         run: |
-          ver=latest
-          if [ "${{ inputs.verset }}" = "minver" ]; then
-            ver=$(iguana_src/meson/minimum-version.sh root tag)
-          fi
-          echo ver=$ver >> $GITHUB_OUTPUT
-          echo key=root---${{ inputs.id }}---${ver}---$(date +%Y-week%U) >> $GITHUB_OUTPUT
+          [ "${{ inputs.verset }}" = "minver" ] && root_version=$(iguana_src/meson/minimum-version.sh root tag) || root_version='latest'
+          echo root_version=$root_version >> $GITHUB_OUTPUT
+          echo key=root---${{ inputs.id }}---${root_version}---$(date +%Y-week%U) >> $GITHUB_OUTPUT
+      ### cache restore
       - uses: actions/cache/restore@v4
         id: cache
         with:
           key: ${{ steps.key.outputs.key }}
           path: root.tar.zst
           lookup-only: true
+      ### download and build
       - name: install dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: iguana_src/.github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}
       - name: download ROOT source code
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
-          iguana_src/.github/download-ROOT-source.rb ${{ steps.key.outputs.ver }}
+          iguana_src/.github/download-ROOT-source.rb ${{ steps.key.outputs.root_version }}
           tar xf $(ls -t *.gz | head -n1)
           ls -t
           mv -v $(ls -td root-* | head -n1) root_src
@@ -123,6 +124,7 @@ jobs:
           cmake --build build
           cmake --install build
           tar caf root{.tar.zst,}
+      ### cache save
       - uses: actions/cache/save@v4
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         id: cache_save
@@ -146,6 +148,7 @@ jobs:
     outputs:
       key: ${{ steps.key.outputs.key }}
     steps:
+      ### get ROOT
       - name: get ROOT build
         if: ${{ matrix.root_dep == 'withROOT' }}
         uses: actions/cache/restore@v4
@@ -155,15 +158,18 @@ jobs:
       - name: untar ROOT build
         if: ${{ matrix.root_dep == 'withROOT' }}
         run: ls *.tar.zst | xargs -I{} tar xvf {}
+      ### define key
       - name: key
         id: key
         run: echo key=hipo---${{ inputs.id }}---${{ env.hipo_ref }}---$(date +%Y-week%U) >> $GITHUB_OUTPUT
+      ### cache restore
       - uses: actions/cache/restore@v4
         id: cache
         with:
           key: ${{ steps.key.outputs.key }}---${{ matrix.root_dep }}
           path: hipo.tar.zst
           lookup-only: true
+      ### build
       - name: checkout iguana for dependency installation script
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         uses: actions/checkout@v4
@@ -185,6 +191,7 @@ jobs:
           cmake --build build
           cmake --install build
           tar cavf hipo{.tar.zst,}
+      ### cache save
       - uses: actions/cache/save@v4
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         id: cache_save

--- a/meson/minimum-version.sh
+++ b/meson/minimum-version.sh
@@ -11,12 +11,16 @@ if [ $# -eq 0 ]; then
             ALA     return a URL for the Arch Linux Archive (ALA), for CI
                     https://archive.archlinux.org/
 
-            src     return a URL of the source code
+            tag     return a git tag for the minimum version's source code
   """
   exit 2
 fi
 dep=$1
 [ $# -ge 2 ] && cmd=$2 || cmd=meson
+
+not_used() {
+  [ "$cmd" = "$1" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1
+}
 
 #############################################
 
@@ -24,17 +28,17 @@ case $dep in
   fmt)
     result_meson='>=9.1.0'
     result_ala='https://archive.archlinux.org/packages/f/fmt/fmt-9.1.0-4-x86_64.pkg.tar.zst'
-    [ "$cmd" = "src" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1
+    not_used 'tag'
     ;;
   yaml-cpp)
     result_meson='>=0.7.0'
     result_ala='https://archive.archlinux.org/packages/y/yaml-cpp/yaml-cpp-0.7.0-2-x86_64.pkg.tar.zst'
-    [ "$cmd" = "src" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1
+    not_used 'tag'
     ;;
   root|ROOT)
-    result_meson='>=6.28'
-    [ "$cmd" = "ALA" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1
-    result_src='https://root.cern/download/root_v6.28.12.source.tar.gz'
+    result_meson='>=6.28.12'
+    result_tag='v6-28-12'
+    not_used 'ALA'
     ;;
   *)
     echo "ERROR: dependency '$dep' is unknown" >&2
@@ -47,7 +51,7 @@ esac
 case $cmd in
   meson) echo $result_meson ;;
   ALA)   echo $result_ala   ;;
-  src)   echo $result_src   ;;
+  tag)   echo $result_tag   ;;
   *)
     echo "ERROR: command '$cmd' is unknown" >&2
     exit 1


### PR DESCRIPTION
Issues this PR resolves:
- [x] we have only been testing on one version of ROOT, v6.28.12; all other major dependencies get their minimum and latest versions tested
- [x] according to #251 tests, a newer version of ROOT breaks `pyiguana`
  - resolved by #250 by avoiding returning `std::tuple`
- [x] #259, which means we are currently unable to test on macOS