### PR TITLE
build: decrease ROOT minimum version 6.28.12 -> 6.28.10

### DIFF
--- a/meson/minimum-version.sh
+++ b/meson/minimum-version.sh
@@ -36,8 +36,8 @@ case $dep in
     not_used 'tag'
     ;;
   root|ROOT)
-    result_ver='6.28.12'
-    result_tag='v6-28-12'
+    result_ver='6.28.10'
+    result_tag='v6-28-10'
     not_used 'ALA'
     ;;
   ruby)


### PR DESCRIPTION
`ifarm` has the following modules:
```
----------------------------------------- /scigroup/cvmfs/hallb/clas12/sw/modulefiles -----------------------------------------
root/6.30.04  root/6.32.02

----------------------------------------- /scigroup/cvmfs/scicomp/sw/el9/modulefiles ------------------------------------------
root/6.24.08-gcc11.4.0  root/6.28.10-gcc11.4.0  root/6.30.04-gcc11.4.0
root/6.26.14-gcc11.4.0  root/6.30.02-gcc11.4.0  root/6.30.06-gcc11.4.0
```
So `clas12` modules prefer 6.30+, but older ones are installed in `el9` modules.

I've been doing most of my local testing with 6.28.10, so let's decrease the `patch` version down a bit (before #264 we didn't care about the patch version, and just required 6.28+).
I don't really want to re-build ROOT locally (and my dependent analysis code), so this PR is mainly just for me.

**If anyone wants an even older minimum version, please open an issue or a PR similar to this one**