### PR TITLE
fix(ci): fallback to alternate ALA mirror

### DIFF
--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -116,7 +116,10 @@ case $runner in
       echo "[+] INSTALLING PACKAGE $pkg"
       case $verset in
         latest) pacman -S --noconfirm $pkg ;;
-        minver) pacman -U --noconfirm --disable-download-timeout $($this_dir/meson/minimum-version.sh $pkg ALA) ;;
+        minver)
+          pacman -U --noconfirm $($this_dir/meson/minimum-version.sh $pkg ALA) || \
+          pacman -U --noconfirm $($this_dir/meson/minimum-version.sh $pkg ALA https://america.archive.pkgbuild.com)
+          ;;
       esac
       info_pacman $pkg
     done

--- a/.github/install-dependency-packages.sh
+++ b/.github/install-dependency-packages.sh
@@ -116,7 +116,7 @@ case $runner in
       echo "[+] INSTALLING PACKAGE $pkg"
       case $verset in
         latest) pacman -S --noconfirm $pkg ;;
-        minver) pacman -U --noconfirm $($this_dir/meson/minimum-version.sh $pkg ALA) ;;
+        minver) pacman -U --noconfirm --disable-download-timeout $($this_dir/meson/minimum-version.sh $pkg ALA) ;;
       esac
       info_pacman $pkg
     done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,6 @@ jobs:
           path: root.tar.zst
           lookup-only: true
       ### download and build
-      - name: debug
-        run: ping -c5 archive.archlinux.org
       - name: install dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: iguana_src/.github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
           path: root.tar.zst
           lookup-only: true
       ### download and build
+      - name: debug
+        run: ping -c5 archive.archlinux.org
       - name: install dependencies
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: iguana_src/.github/install-dependency-packages.sh ${{ inputs.runner }} ${{ inputs.verset }}

--- a/meson/minimum-version.sh
+++ b/meson/minimum-version.sh
@@ -1,25 +1,33 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+cmd=ver
+ala_mirror='https://archive.archlinux.org'
 if [ $# -eq 0 ]; then
-  echo """USAGE: $0 [package] [command(default=ver)]
+  echo """USAGE: $0 [package] [command] [ALA_mirror]
 
   package:  the package name; since this varies between package manager
             repositories, we prefer to use the name from that used by the CI
 
-  command:  ver     return the minimum version number
+  command:
+    choices:  ver  return the minimum version number
+              ALA  return a URL for the Arch Linux Archive (ALA), for CI
+              tag  return a git tag for the minimum version's source code
+    default: $cmd
 
-            ALA     return a URL for the Arch Linux Archive (ALA), for CI
-                    https://archive.archlinux.org/
+  ALA_mirror:  the ALA mirror, for command 'ALA'
+    default: $ala_mirror
 
-            tag     return a git tag for the minimum version's source code
   """
   exit 2
 fi
 dep=$1
-[ $# -ge 2 ] && cmd=$2 || cmd=ver
+[ $# -ge 2 ] && cmd=$2
+[ $# -ge 3 ] && ala_mirror=$3
 
 not_used() {
-  [ "$cmd" = "$1" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1
+  [ "$cmd" = "$1" ] && echo "ERROR: command '$cmd' is not used for '$dep'" >&2 && exit 1 || true
 }
 
 #############################################
@@ -27,12 +35,12 @@ not_used() {
 case $dep in
   fmt)
     result_ver='9.1.0'
-    result_ala='https://archive.archlinux.org/packages/f/fmt/fmt-9.1.0-4-x86_64.pkg.tar.zst'
+    result_ala="$ala_mirror/packages/f/fmt/fmt-9.1.0-4-x86_64.pkg.tar.zst"
     not_used 'tag'
     ;;
   yaml-cpp)
     result_ver='0.7.0'
-    result_ala='https://archive.archlinux.org/packages/y/yaml-cpp/yaml-cpp-0.7.0-2-x86_64.pkg.tar.zst'
+    result_ala="$ala_mirror/packages/y/yaml-cpp/yaml-cpp-0.7.0-2-x86_64.pkg.tar.zst"
     not_used 'tag'
     ;;
   root|ROOT)


### PR DESCRIPTION
The [Arch Linux Archive](https://wiki.archlinux.org/title/Arch_Linux_Archive), used in our minver tests, may sometimes be inaccessible; this PR allows for fallback to an alternate mirror when the main one fails.