### PR TITLE
fix: workaround `-Wstringop-overflow` warnings from `fmt`

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -43,7 +43,7 @@ foreach example, info : example_sources
           [ get_option('test_data_file'), '100' ], # don't run too many events, or meson test log will be huge
         ),
         env: project_test_env,
-        timeout: 60,
+        timeout: 120,
       )
     endif
   endif

--- a/meson.build
+++ b/meson.build
@@ -176,7 +176,7 @@ project_test_env.set(
 # set compiler options
 add_project_arguments(
   '-DIGUANA_ETCDIR="' + get_option('prefix') / project_etc + '"',
-  '-Wno-stringop-overflow', # workaround https://github.com/fmtlib/fmt/issues/4133
+  meson.get_compiler('cpp').get_id() == 'gcc' ? '-Wno-stringop-overflow' : '-Wno-shift-overflow', # workaround https://github.com/fmtlib/fmt/issues/4133
   language: [ 'cpp' ],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -173,10 +173,9 @@ project_test_env.set(
   'suppressions=' + meson.project_source_root() / 'meson' / 'lsan.supp',
 )
 
-# set compiler options
+# set preprocessor macros
 add_project_arguments(
   '-DIGUANA_ETCDIR="' + get_option('prefix') / project_etc + '"',
-  meson.get_compiler('cpp').get_id() == 'gcc' ? '-Wno-stringop-overflow' : '-Wno-shift-overflow', # workaround https://github.com/fmtlib/fmt/issues/4133
   language: [ 'cpp' ],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -173,9 +173,10 @@ project_test_env.set(
   'suppressions=' + meson.project_source_root() / 'meson' / 'lsan.supp',
 )
 
-# set preprocessor macros
+# set compiler options
 add_project_arguments(
   '-DIGUANA_ETCDIR="' + get_option('prefix') / project_etc + '"',
+  '-Wno-stringop-overflow', # workaround https://github.com/fmtlib/fmt/issues/4133
   language: [ 'cpp' ],
 )
 

--- a/src/iguana/services/Logger.h
+++ b/src/iguana/services/Logger.h
@@ -1,8 +1,22 @@
 #pragma once
 
+// workaround https://github.com/fmtlib/fmt/issues/4133
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshift-overflow"
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 #include <fmt/color.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#else
+#pragma GCC diagnostic pop
+#endif
+
 #include <functional>
 #include <unordered_map>
 


### PR DESCRIPTION
Workaround https://github.com/fmtlib/fmt/issues/4133 until fixed (so we can continue to use `-Werror` on CI here). Revert when fixed.

fixes #277 