### PR TITLE
refactor!: remove `ThreadPoolParam`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,10 +408,10 @@ jobs:
       - name: benchmark algorithms
         if: ${{ matrix.id == 'coverage' }} # use the coverage job's GITHUB_STEP_SUMMARY
         run: |
-          for suite in single_threaded memoize threadpool; do
+          for suite in single_threaded memoize; do
             meson test --benchmark --suite $suite -C iguana_build | tee benchmark_$suite.txt
           done
-          iguana_src/.github/make-benchmark-table.rb benchmark_{single_threaded,memoize,threadpool}.txt | xargs -0 -I{} echo {} >> $GITHUB_STEP_SUMMARY
+          iguana_src/.github/make-benchmark-table.rb benchmark_{single_threaded,memoize}.txt | xargs -0 -I{} echo {} >> $GITHUB_STEP_SUMMARY
       ### coverage
       - name: coverage
         if: ${{ matrix.id == 'coverage' }}

--- a/doc/gen/Doxyfile.in
+++ b/doc/gen/Doxyfile.in
@@ -296,7 +296,6 @@ ALIASES += config_param{3|}="<tr><td>`\1`</td><td>`\2`</td><td>\3</td></tr>"
 # action functions
 ALIASES += action_function{1}="\xrefitem action \"Function Type\" \"List of all Action Functions\" \1 \brief **Action Function:** "
 ALIASES += when_to_call{1}="@note This function should be called **\1**"
-ALIASES += thread_id_desc="the thread index, if using `GlobalConcurrencyModel == \"threadpool\"`; otherwise, just use the default value"
 # examples
 ALIASES += begin_doc_example{1}="@addtogroup examples_\1^^@{"
 ALIASES += end_doc_example="@}"

--- a/examples/iguana_ex_fortran_01_action_functions.f
+++ b/examples/iguana_ex_fortran_01_action_functions.f
@@ -188,12 +188,11 @@ c       read banks
 c       before using the Z-vertext filter, we must "prepare" the
 c       algorithm's configuration for this event; the resulting
 c       'key_vz_filter' must be passed to the action function;
-c       we leave the `thread_id` at zero (since we don't need it)
         call iguana_clas12_zvertexfilter_prepareevent(
-     &      algo_vz_filter, runnum(1), 0, key_vz_filter)
+     &      algo_vz_filter, runnum(1), key_vz_filter)
 c       similarly for the inclusive kinematics algorithm
         call iguana_physics_inclusivekinematics_prepareevent(
-     &      algo_inc_kin, runnum(1), 0, key_inc_kin)
+     &      algo_inc_kin, runnum(1), key_inc_kin)
 
 c       call iguana filters
 c       - the `logical` variable `accept` must be initialized to

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -65,8 +65,7 @@ namespace iguana {
 
       /// @brief Run this algorithm for an event.
       /// @param banks the list of banks to process
-      /// @param thread_id @thread_id_desc
-      virtual void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const = 0;
+      virtual void Run(hipo::banklist& banks) const = 0;
 
       /// @brief Finalize this algorithm after all events are processed.
       virtual void Stop() = 0;

--- a/src/iguana/algorithms/AlgorithmSequence.cc
+++ b/src/iguana/algorithms/AlgorithmSequence.cc
@@ -9,10 +9,10 @@ namespace iguana {
     for(auto const& algo : m_sequence)
       algo->Start(banks);
   }
-  void AlgorithmSequence::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void AlgorithmSequence::Run(hipo::banklist& banks) const
   {
     for(auto const& algo : m_sequence)
-      algo->Run(banks, thread_id);
+      algo->Run(banks);
   }
   void AlgorithmSequence::Stop()
   {

--- a/src/iguana/algorithms/AlgorithmSequence.h
+++ b/src/iguana/algorithms/AlgorithmSequence.h
@@ -16,7 +16,7 @@ namespace iguana {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// Create and add an algorithm to the sequence, by name.

--- a/src/iguana/algorithms/Validator.h
+++ b/src/iguana/algorithms/Validator.h
@@ -27,7 +27,7 @@ namespace iguana {
       virtual ~Validator() {}
 
       void Start(hipo::banklist& banks) override{};
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override{};
+      void Run(hipo::banklist& banks) const override{};
       void Stop() override{};
 
       /// Set this validator's output directory

--- a/src/iguana/algorithms/clas12/EventBuilderFilter/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/EventBuilderFilter/Algorithm.cc
@@ -16,7 +16,7 @@ namespace iguana::clas12 {
   }
 
 
-  void EventBuilderFilter::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void EventBuilderFilter::Run(hipo::banklist& banks) const
   {
 
     // get the banks

--- a/src/iguana/algorithms/clas12/EventBuilderFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/EventBuilderFilter/Algorithm.h
@@ -22,7 +22,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// @action_function{scalar filter} checks if the PDG `pid` is a part of the list of user-specified PDGs

--- a/src/iguana/algorithms/clas12/FTEnergyCorrection/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/FTEnergyCorrection/Algorithm.cc
@@ -8,7 +8,7 @@ namespace iguana::clas12 {
     electron_mass = particle::mass.at(particle::electron);
   }
 
-  void FTEnergyCorrection::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const {
+  void FTEnergyCorrection::Run(hipo::banklist& banks) const {
     auto& ftParticleBank = GetBank(banks, b_ft_particle, "RECFT::Particle");
     ShowBank(ftParticleBank, Logger::Header("INPUT FT PARTICLES"));
     for(auto const& row : ftParticleBank.getRowList()) {

--- a/src/iguana/algorithms/clas12/FTEnergyCorrection/Algorithm.h
+++ b/src/iguana/algorithms/clas12/FTEnergyCorrection/Algorithm.h
@@ -17,7 +17,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// @action_function{scalar transformer}

--- a/src/iguana/algorithms/clas12/FiducialFilter/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/FiducialFilter/Algorithm.cc
@@ -21,7 +21,7 @@ namespace iguana::clas12 {
       
   }
 
-void FiducialFilter::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const {
+void FiducialFilter::Run(hipo::banklist& banks) const {
     // get the banks
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
     auto& trajBank     = GetBank(banks, b_traj, "REC::Traj");

--- a/src/iguana/algorithms/clas12/FiducialFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/FiducialFilter/Algorithm.h
@@ -22,7 +22,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// structure to hold `REC::Traj` data

--- a/src/iguana/algorithms/clas12/FiducialFilter/Validator.cc
+++ b/src/iguana/algorithms/clas12/FiducialFilter/Validator.cc
@@ -83,7 +83,7 @@ namespace iguana::clas12 {
   }
 
 
-  void FiducialFilterValidator::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void FiducialFilterValidator::Run(hipo::banklist& banks) const
   {
     // get the momenta before
     auto& particle_bank = GetBank(banks, b_particle, "REC::Particle");
@@ -104,7 +104,7 @@ namespace iguana::clas12 {
     }
 
     // run the fiducial cuts
-    m_algo_seq->Run(banks, thread_id);
+    m_algo_seq->Run(banks);
 
     // fill the plots
     for(auto const& row : particle_bank.getRowList()) {

--- a/src/iguana/algorithms/clas12/FiducialFilter/Validator.h
+++ b/src/iguana/algorithms/clas12/FiducialFilter/Validator.h
@@ -17,7 +17,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
       
     private:

--- a/src/iguana/algorithms/clas12/LorentzTransformer/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/LorentzTransformer/Algorithm.cc
@@ -32,7 +32,7 @@ namespace iguana::clas12 {
   }
 
 
-  void LorentzTransformer::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void LorentzTransformer::Run(hipo::banklist& banks) const
   {
 
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");

--- a/src/iguana/algorithms/clas12/LorentzTransformer/Algorithm.h
+++ b/src/iguana/algorithms/clas12/LorentzTransformer/Algorithm.h
@@ -27,7 +27,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// @action_function{scalar transformer} boost the 4-momentum @f$p=(p_x,p_y,p_z,E)@f$ along @f$\beta=(\beta_x, \beta_y, \beta_z)@f$

--- a/src/iguana/algorithms/clas12/MomentumCorrection/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/MomentumCorrection/Algorithm.cc
@@ -13,7 +13,7 @@ namespace iguana::clas12 {
   }
 
 
-  void MomentumCorrection::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void MomentumCorrection::Run(hipo::banklist& banks) const
   {
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
     auto& sectorBank   = GetBank(banks, b_sector, "REC::Particle::Sector");

--- a/src/iguana/algorithms/clas12/MomentumCorrection/Algorithm.h
+++ b/src/iguana/algorithms/clas12/MomentumCorrection/Algorithm.h
@@ -20,7 +20,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// @action_function{scalar transformer} Apply the momentum correction

--- a/src/iguana/algorithms/clas12/MomentumCorrection/Validator.cc
+++ b/src/iguana/algorithms/clas12/MomentumCorrection/Validator.cc
@@ -48,7 +48,7 @@ namespace iguana::clas12 {
   }
 
 
-  void MomentumCorrectionValidator::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void MomentumCorrectionValidator::Run(hipo::banklist& banks) const
   {
     // get the momenta before
     auto& particle_bank = GetBank(banks, b_particle, "REC::Particle");
@@ -61,7 +61,7 @@ namespace iguana::clas12 {
           particle_bank.getFloat("pz", row)));
 
     // run the momentum corrections
-    m_algo_seq->Run(banks, thread_id);
+    m_algo_seq->Run(banks);
 
     // lock the mutex, so we can mutate plots
     std::scoped_lock<std::mutex> lock(m_mutex);

--- a/src/iguana/algorithms/clas12/MomentumCorrection/Validator.h
+++ b/src/iguana/algorithms/clas12/MomentumCorrection/Validator.h
@@ -17,7 +17,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
     private:

--- a/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.cc
@@ -18,7 +18,7 @@ namespace iguana::clas12 {
 
 
     
-  void PhotonGBTFilter::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void PhotonGBTFilter::Run(hipo::banklist& banks) const
   {
       
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");

--- a/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/PhotonGBTFilter/Algorithm.h
@@ -34,7 +34,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;   
 
       /// **Method**: Applies forward detector cut using REC::Particle Theta

--- a/src/iguana/algorithms/clas12/PhotonGBTFilter/Validator.cc
+++ b/src/iguana/algorithms/clas12/PhotonGBTFilter/Validator.cc
@@ -26,7 +26,7 @@ namespace iguana::clas12 {
     InitializeHistograms();
   }
 
-  void PhotonGBTFilterValidator::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void PhotonGBTFilterValidator::Run(hipo::banklist& banks) const
   {
     // get the particle bank
     auto& particle_bank = GetBank(banks, b_particle, "REC::Particle");
@@ -45,7 +45,7 @@ namespace iguana::clas12 {
     }
 
     // run the photon filter
-    m_algo_seq->Run(banks, thread_id);
+    m_algo_seq->Run(banks);
       
     std::vector<ROOT::Math::PxPyPzEVector> filtered_photons;
     for(auto const& row : particle_bank.getRowList()) {

--- a/src/iguana/algorithms/clas12/PhotonGBTFilter/Validator.h
+++ b/src/iguana/algorithms/clas12/PhotonGBTFilter/Validator.h
@@ -19,7 +19,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
     private:

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
@@ -49,7 +49,7 @@ namespace iguana::clas12 {
     i_pindex = result_schema.getEntryOrder("pindex");
   }
 
-  void SectorFinder::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void SectorFinder::Run(hipo::banklist& banks) const
   {
     auto& particleBank = GetBank(banks, b_particle, "REC::Particle");
     auto& resultBank   = GetBank(banks, b_result, "REC::Particle::Sector");

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -22,7 +22,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// @action_function{vector creator} for a given particle with index `pindex`, get its sector from a detector bank's list of `sectors` and `pindices` (both must be ordered in the same way);

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.cc
@@ -54,7 +54,7 @@ namespace iguana::clas12 {
 
   }
 
-  void SectorFinderValidator::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void SectorFinderValidator::Run(hipo::banklist& banks) const
   {
     
     auto& particle_bank = GetBank(banks, b_particle, "REC::Particle");
@@ -62,7 +62,7 @@ namespace iguana::clas12 {
     auto& cal_bank = GetBank(banks, b_cal, "REC::Calorimeter");
 
     
-    m_algo_seq->Run(banks, thread_id);
+    m_algo_seq->Run(banks);
 
     // lock the mutex, so we can mutate plots
     std::scoped_lock<std::mutex> lock(m_mutex);

--- a/src/iguana/algorithms/clas12/SectorFinder/Validator.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Validator.h
@@ -18,7 +18,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
     private:

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Action.yaml
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Action.yaml
@@ -7,9 +7,6 @@ actions:
     inputs:
       - name: runnum
         type: int
-      - name: thread_id
-        type: concurrent_key_t
-        cast: int
     outputs:
       - type: concurrent_key_t
         cast: int

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.h
@@ -23,15 +23,14 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// @action_function{reload} prepare the event
       /// @when_to_call{for each event}
       /// @param runnum the run number
-      /// @param thread_id @thread_id_desc
       /// @returns the key to be used in `::Filter`
-      concurrent_key_t PrepareEvent(int const runnum, concurrent_key_t thread_id = 0) const;
+      concurrent_key_t PrepareEvent(int const runnum) const;
 
       /// @action_function{scalar filter} checks if the Z Vertex is within specified bounds if pid is one for which the filter should be applied to.;
       /// Cuts applied to particles in FD or CD (ie not in FT).

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Validator.cc
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Validator.cc
@@ -49,7 +49,7 @@ namespace iguana::clas12 {
   }
 
 
-  void ZVertexFilterValidator::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void ZVertexFilterValidator::Run(hipo::banklist& banks) const
   {
     auto& particle_bank = GetBank(banks, b_particle, "REC::Particle");
 
@@ -69,7 +69,7 @@ namespace iguana::clas12 {
     }
       
     // run the momentum corrections
-    m_algo_seq->Run(banks, thread_id);
+    m_algo_seq->Run(banks);
 
     // fill the plots after
     for(auto const& row : particle_bank.getRowList()) {

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Validator.h
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Validator.h
@@ -16,7 +16,7 @@ namespace iguana::clas12 {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
     private:

--- a/src/iguana/algorithms/example/ExampleAlgorithm/Algorithm.cc
+++ b/src/iguana/algorithms/example/ExampleAlgorithm/Algorithm.cc
@@ -59,7 +59,7 @@ namespace iguana::example {
   // # - try to avoid expensive operations here; instead, put them in the `Start` method
   // #   if it is reasonable to do so
   // ############################################################################
-  void ExampleAlgorithm::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void ExampleAlgorithm::Run(hipo::banklist& banks) const
   {
     // ############################################################################
     // # get the banks; here we just need `REC::Particle`

--- a/src/iguana/algorithms/example/ExampleAlgorithm/Algorithm.h
+++ b/src/iguana/algorithms/example/ExampleAlgorithm/Algorithm.h
@@ -63,7 +63,7 @@ namespace iguana::example {
       // # - each algorithm must have these methods (even if they do nothing)
       // ############################################################################
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       // ############################################################################

--- a/src/iguana/algorithms/physics/InclusiveKinematics/Action.yaml
+++ b/src/iguana/algorithms/physics/InclusiveKinematics/Action.yaml
@@ -7,9 +7,6 @@ actions:
     inputs:
       - name: runnum
         type: int
-      - name: thread_id
-        type: concurrent_key_t
-        cast: int
     outputs:
       - type: concurrent_key_t
         cast: int

--- a/src/iguana/algorithms/physics/InclusiveKinematics/Algorithm.h
+++ b/src/iguana/algorithms/physics/InclusiveKinematics/Algorithm.h
@@ -47,15 +47,14 @@ namespace iguana::physics {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
       /// @action_function{reload} prepare the event
       /// @when_to_call{for each event}
       /// @param runnum the run number
-      /// @param thread_id @thread_id_desc
       /// @returns the key to be used in `::ComputeFromLepton`
-      concurrent_key_t PrepareEvent(int const runnum, concurrent_key_t thread_id = 0) const;
+      concurrent_key_t PrepareEvent(int const runnum) const;
 
       /// @action_function{scalar creator} compute kinematics from the scattered lepton.
       /// @param lepton_px scattered lepton momentum component @f$p_x@f$ (GeV)

--- a/src/iguana/algorithms/physics/InclusiveKinematics/Validator.cc
+++ b/src/iguana/algorithms/physics/InclusiveKinematics/Validator.cc
@@ -52,10 +52,10 @@ namespace iguana::physics {
   }
 
 
-  void InclusiveKinematicsValidator::Run(hipo::banklist& banks, concurrent_key_t const thread_id) const
+  void InclusiveKinematicsValidator::Run(hipo::banklist& banks) const
   {
     // calculate kinematics
-    m_algo_seq->Run(banks, thread_id);
+    m_algo_seq->Run(banks);
     auto& particle_bank = GetBank(banks, b_particle, "REC::Particle");
     auto& result_bank   = GetBank(banks, b_result, "physics::InclusiveKinematics");
 

--- a/src/iguana/algorithms/physics/InclusiveKinematics/Validator.h
+++ b/src/iguana/algorithms/physics/InclusiveKinematics/Validator.h
@@ -18,7 +18,7 @@ namespace iguana::physics {
     public:
 
       void Start(hipo::banklist& banks) override;
-      void Run(hipo::banklist& banks, concurrent_key_t const thread_id = 0) const override;
+      void Run(hipo::banklist& banks) const override;
       void Stop() override;
 
     private:

--- a/src/iguana/services/ConcurrentParam.h
+++ b/src/iguana/services/ConcurrentParam.h
@@ -102,30 +102,6 @@ namespace iguana {
   };
 
   // ==================================================================================
-  // ThreadPoolParam
-  // ==================================================================================
-
-  /// @brief a `ConcurrentParam` that uses unique thread-pool indices for thread safety
-  template <typename T>
-  class ThreadPoolParam : public ConcurrentParam<T> {
-
-    /// hash table container for memoization
-    using container_t = std::vector<T>;
-
-    public:
-      ThreadPoolParam();
-      ~ThreadPoolParam() override = default;
-      T const Load(concurrent_key_t const key) const override;
-      void Save(T const& value, concurrent_key_t const key) override;
-      bool HasKey(concurrent_key_t const key) const override;
-      std::size_t GetSize() const override;
-
-    private:
-      container_t m_container;
-
-  };
-
-  // ==================================================================================
   // ConcurrentParamFactory
   // ==================================================================================
 
@@ -147,10 +123,8 @@ namespace iguana {
           return std::make_unique<SingleThreadParam<T>>();
         else if(GlobalConcurrencyModel() == "memoize")
           return std::make_unique<MemoizedParam<T>>();
-        else if(GlobalConcurrencyModel() == "threadpool")
-          return std::make_unique<ThreadPoolParam<T>>();
 
-        throw std::runtime_error("unknown GlobalConcurrencyModel '" + GlobalConcurrencyModel() + "'");
+        throw std::runtime_error("unknown GlobalConcurrencyModel '" + GlobalConcurrencyModel() + "'; valid options are 'single' or 'memoize'");
       }
 
   };

--- a/src/iguana/tests/iguana_test.cc
+++ b/src/iguana/tests/iguana_test.cc
@@ -99,8 +99,7 @@ int main(int argc, char** argv)
         {"m", [&]()
          {
            fmt::print("    {:<20} {}\n", "-m CONCURRENCY_MODEL", "concurrency model");
-           fmt::print("    {:<20} 'single', 'memoize', or 'threadpool'\n", "");
-           fmt::print("    {:<20} default: use the internal default\n", "");
+           fmt::print("    {:<20} 'memoize' is currently the only option\n", "");
          }},
         {"V", [&]()
          {

--- a/src/iguana/tests/include/TestMultithreading.h
+++ b/src/iguana/tests/include/TestMultithreading.h
@@ -135,7 +135,7 @@ inline int TestMultithreading(
           }
 
           // run the iguana algorithm
-          seq.Run(banks, order);
+          seq.Run(banks);
         }
       }
       if(nNonEmpty == 0)

--- a/src/iguana/tests/meson.build
+++ b/src/iguana/tests/meson.build
@@ -57,7 +57,7 @@ foreach algo : algo_dict
       )
 
       # multithreaded tests
-      foreach concurrency_model : [ 'memoize', 'threadpool' ]
+      foreach concurrency_model : [ 'memoize' ] # note: we used to have more, so leave this array in case we want more
         multithreading_args = [
           'multithreading',
           '-j', get_option('test_multithreading').to_string(),
@@ -67,7 +67,7 @@ foreach algo : algo_dict
         test(
           '-'.join(['multithreading', concurrency_model, test_name_algo]),
           test_exe,
-          suite: [ 'multithreading', concurrency_model ],
+          suite: [ 'algorithm', 'multithreading', concurrency_model ],
           args: multithreading_args + [ '-n', get_option('test_num_events') ] + test_args,
           is_parallel: false,
           env: project_test_env,
@@ -76,7 +76,7 @@ foreach algo : algo_dict
         benchmark(
           '-'.join(['benchmark', f'multithreading_@concurrency_model@', test_name_algo]),
           test_exe,
-          suite: [ 'multithreading', concurrency_model ],
+          suite: [ 'algorithm', 'multithreading', concurrency_model ],
           args: multithreading_args + [ '-n', '0' ] + test_args, # benchmark all the events
           env: project_test_env,
           timeout: 0,


### PR DESCRIPTION
See discussion and benchmarks in #258. In summary,
- `ThreadPoolParam` is only sometimes better than `MemoizedParam`, but in some cases, can be significantly worse
- Addition of `thread_id` parameter to `Algorithm::Run` and reload-type action functions reduces user-friendliness of those functions