### PR TITLE
fix: handle wrapper arguments when sourcing `this_iguana.sh`

### DIFF
--- a/meson/this_iguana.sh.in
+++ b/meson/this_iguana.sh.in
@@ -22,6 +22,8 @@ for arg in "$@"; do
       unset arg_githubCI
       return 2
       ;;
+    source*|.*) # handle callers which cause `$1` to be 'source this_iguana.sh' or '. this_iguana.sh'
+      ;;
     *)
       echo "ERROR: unknown option '$arg'" >&2
       unset arg


### PR DESCRIPTION
For example, this allows [`bass`](https://github.com/edc/bass) to work.