### PR TITLE
feat: set algorithm log levels from config `yaml` files

### DIFF
--- a/examples/config/my_combined_config_file.yaml
+++ b/examples/config/my_combined_config_file.yaml
@@ -21,17 +21,15 @@ example::ExampleAlgorithm:
 
 clas12::ZVertexFilter:
 
-  # default cuts
+  log: debug  # NOTE: you may control algorithm log levels here, like so
+
+  electron:
   - default:
-    electron_vz: [ -33.0, 11.0 ]
-
-  #RG-A fall2018 inbending
+    vz: [ -33.0, 11.0 ]
   - runs: [ 4760, 5419 ]
-    electron_vz: [ -13.0, 12.0 ]
-
-   #RG-A fall2018 outbending
+    vz: [ -13.0, 12.0 ]
   - runs: [ 5420, 5674 ]
-    electron_vz: [ -18.0, 10.0 ]
+    vz: [ -18.0, 10.0 ]
 
 another::Algorithm:
   #Cuts below are just examples:

--- a/examples/config/my_config_directory/algorithms/clas12/ZVertexFilter/Config.yaml
+++ b/examples/config/my_config_directory/algorithms/clas12/ZVertexFilter/Config.yaml
@@ -1,14 +1,17 @@
 # Cut values for different run periods
 clas12::ZVertexFilter:
 
-  # default cuts
-  - default:
-    electron_vz: [ -15.0, 15.0 ]
+  # scattered electron cuts
+  electron:
 
-  # RG-A fall2018 inbending
-  - runs: [ 4760, 5419 ]
-    electron_vz: [ -5.0, 3.0 ]
+    # default cuts
+    - default:
+      vz: [ -15.0, 15.0 ]
 
-  # RG-A fall2018 outbending
-  - runs: [ 5420, 5674 ]
-    electron_vz: [ -8.0, 7.0 ]
+    # RG-A fall2018 inbending
+    - runs: [ 4760, 5419 ]
+      vz: [ -5.0, 3.0 ]
+
+    # RG-A fall2018 outbending
+    - runs: [ 5420, 5674 ]
+      vz: [ -8.0, 7.0 ]

--- a/examples/config/my_z_vertex_cuts.yaml
+++ b/examples/config/my_z_vertex_cuts.yaml
@@ -1,6 +1,13 @@
 # Cut values for different run periods
 clas12::ZVertexFilter:
 
+  # NOTE: you can set the log level from the configuration file
+  log: trace
+
+  # FIXME: with the addition of `log`, this is now
+  # now a proper YAML file; the list below should be put
+  # in their own separate node
+
   # default cuts
   - default:
     electron_vz: [ -1.5, 1.3 ]

--- a/examples/config/my_z_vertex_cuts.yaml
+++ b/examples/config/my_z_vertex_cuts.yaml
@@ -1,21 +1,22 @@
 # Cut values for different run periods
 clas12::ZVertexFilter:
 
-  # NOTE: you can set the log level from the configuration file
+  ###################################################################################
+  # NOTE: for convenience, you can also set the log level from the configuration file
   log: trace
+  ###################################################################################
 
-  # FIXME: with the addition of `log`, this is now
-  # now a proper YAML file; the list below should be put
-  # in their own separate node
+  # scattered electron cuts
+  electron:
 
-  # default cuts
-  - default:
-    electron_vz: [ -1.5, 1.3 ]
+    # default cuts
+    - default:
+      vz: [ -1.5, 1.3 ]
 
-  # RG-A fall2018 inbending
-  - runs: [ 4760, 5419 ]
-    electron_vz: [ -0.5, 0.5 ]
+    # RG-A fall2018 inbending
+    - runs: [ 4760, 5419 ]
+      vz: [ -0.5, 0.5 ]
 
-  # RG-A fall2018 outbending
-  - runs: [ 5420, 5674 ]
-    electron_vz: [ -0.8, 0.7 ]
+    # RG-A fall2018 outbending
+    - runs: [ 5420, 5674 ]
+      vz: [ -0.8, 0.7 ]

--- a/src/iguana/algorithms/Algorithm.h
+++ b/src/iguana/algorithms/Algorithm.h
@@ -88,8 +88,7 @@ namespace iguana {
           else
             m_log->Error("Option '{}' must be a string or a Logger::Level", key);
         }
-        else
-          m_option_cache[key] = val;
+        m_option_cache[key] = val;
         return val;
       }
 

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Algorithm.cc
@@ -64,7 +64,7 @@ namespace iguana::clas12 {
     std::lock_guard<std::mutex> const lock(m_mutex); // NOTE: be sure to lock successive `ConcurrentParam::Save` calls !!!
     m_log->Trace("-> calling Reload({}, {})", runnum, key);
     o_runnum->Save(runnum, key);
-    o_electron_vz_cuts->Save(GetOptionVector<double>("electron_vz", {GetConfig()->InRange("runs", runnum), "electron_vz"}), key);
+    o_electron_vz_cuts->Save(GetOptionVector<double>("electron_vz", {"electron", GetConfig()->InRange("runs", runnum), "vz"}), key);
   }
 
   bool ZVertexFilter::Filter(double const zvertex, int const pid, int const status, concurrent_key_t key) const

--- a/src/iguana/algorithms/clas12/ZVertexFilter/Config.yaml
+++ b/src/iguana/algorithms/clas12/ZVertexFilter/Config.yaml
@@ -1,14 +1,16 @@
-# Cut values for different run periods
 clas12::ZVertexFilter:
 
-  # default cuts
-  - default:
-    electron_vz: [ -20.0, 20.0 ]
+  # scattered electron cuts
+  electron:
 
-  # RG-A fall2018 inbending
-  - runs: [ 4760, 5419 ]
-    electron_vz: [ -13.0, 12.0 ]
+    # default cuts
+    - default:
+      vz: [ -20.0, 20.0 ]
 
-  # RG-A fall2018 outbending
-  - runs: [ 5420, 5674 ]
-    electron_vz: [ -18.0, 10.0 ]
+    # RG-A fall2018 inbending
+    - runs: [ 4760, 5419 ]
+      vz: [ -13.0, 12.0 ]
+
+    # RG-A fall2018 outbending
+    - runs: [ 5420, 5674 ]
+      vz: [ -18.0, 10.0 ]

--- a/src/iguana/services/YAMLReader.cc
+++ b/src/iguana/services/YAMLReader.cc
@@ -22,7 +22,7 @@ namespace iguana {
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename SCALAR>
-  SCALAR YAMLReader::GetScalar(YAML::Node node)
+  std::optional<SCALAR> YAMLReader::GetScalar(YAML::Node node)
   {
     if(node.IsDefined() && !node.IsNull()) {
       try {
@@ -35,32 +35,32 @@ namespace iguana {
         m_log->Error("YAML Misc. Exception: {}", e.what());
       }
     }
-    throw std::runtime_error("Failed `GetScalar`");
+    return std::nullopt;
   }
-  template int YAMLReader::GetScalar(YAML::Node node);
-  template double YAMLReader::GetScalar(YAML::Node node);
-  template std::string YAMLReader::GetScalar(YAML::Node node);
+  template std::optional<int> YAMLReader::GetScalar(YAML::Node node);
+  template std::optional<double> YAMLReader::GetScalar(YAML::Node node);
+  template std::optional<std::string> YAMLReader::GetScalar(YAML::Node node);
 
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename SCALAR>
-  SCALAR YAMLReader::GetScalar(node_path_t node_path)
+  std::optional<SCALAR> YAMLReader::GetScalar(node_path_t node_path)
   {
     for(auto const& [config, filename] : m_configs) {
       auto node = FindNode(config, node_path);
       if(node.IsDefined() && !node.IsNull())
         return GetScalar<SCALAR>(node);
     }
-    throw std::runtime_error("Failed `GetScalar`");
+    return std::nullopt;
   }
-  template int YAMLReader::GetScalar(node_path_t node_path);
-  template double YAMLReader::GetScalar(node_path_t node_path);
-  template std::string YAMLReader::GetScalar(node_path_t node_path);
+  template std::optional<int> YAMLReader::GetScalar(node_path_t node_path);
+  template std::optional<double> YAMLReader::GetScalar(node_path_t node_path);
+  template std::optional<std::string> YAMLReader::GetScalar(node_path_t node_path);
 
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename SCALAR>
-  std::vector<SCALAR> YAMLReader::GetVector(YAML::Node node)
+  std::optional<std::vector<SCALAR>> YAMLReader::GetVector(YAML::Node node)
   {
     if(node.IsDefined() && !node.IsNull() && node.IsSequence()) {
       try {
@@ -76,27 +76,27 @@ namespace iguana {
         m_log->Error("YAML Misc. Exception: {}", e.what());
       }
     }
-    throw std::runtime_error("Failed `GetVector`");
+    return std::nullopt;
   }
-  template std::vector<int> YAMLReader::GetVector(YAML::Node node);
-  template std::vector<double> YAMLReader::GetVector(YAML::Node node);
-  template std::vector<std::string> YAMLReader::GetVector(YAML::Node node);
+  template std::optional<std::vector<int>> YAMLReader::GetVector(YAML::Node node);
+  template std::optional<std::vector<double>> YAMLReader::GetVector(YAML::Node node);
+  template std::optional<std::vector<std::string>> YAMLReader::GetVector(YAML::Node node);
 
   ///////////////////////////////////////////////////////////////////////////////
 
   template <typename SCALAR>
-  std::vector<SCALAR> YAMLReader::GetVector(node_path_t node_path)
+  std::optional<std::vector<SCALAR>> YAMLReader::GetVector(node_path_t node_path)
   {
     for(auto const& [config, filename] : m_configs) {
       auto node = FindNode(config, node_path);
       if(node.IsDefined() && !node.IsNull())
         return GetVector<SCALAR>(node);
     }
-    throw std::runtime_error("Failed `GetVector`");
+    return std::nullopt;
   }
-  template std::vector<int> YAMLReader::GetVector(node_path_t node_path);
-  template std::vector<double> YAMLReader::GetVector(node_path_t node_path);
-  template std::vector<std::string> YAMLReader::GetVector(node_path_t node_path);
+  template std::optional<std::vector<int>> YAMLReader::GetVector(node_path_t node_path);
+  template std::optional<std::vector<double>> YAMLReader::GetVector(node_path_t node_path);
+  template std::optional<std::vector<std::string>> YAMLReader::GetVector(node_path_t node_path);
 
   ///////////////////////////////////////////////////////////////////////////////
 
@@ -114,7 +114,7 @@ namespace iguana {
         auto bounds_node = sub_node[key];
         if(bounds_node.IsDefined()) {
           auto bounds = GetVector<SCALAR>(bounds_node);
-          if(bounds.size() == 2 && bounds[0] <= val && bounds[1] >= val)
+          if(bounds.value().size() == 2 && bounds.value()[0] <= val && bounds.value()[1] >= val)
             return sub_node;
         }
       }

--- a/src/iguana/services/YAMLReader.h
+++ b/src/iguana/services/YAMLReader.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <variant>
 #include <vector>
 
@@ -37,27 +38,27 @@ namespace iguana {
 
       /// Read a scalar value from a `YAML::Node`
       /// @param node the `YAML::Node` to read
-      /// @return the scalar
+      /// @return the scalar, if found
       template <typename SCALAR>
-      SCALAR GetScalar(YAML::Node node);
+      std::optional<SCALAR> GetScalar(YAML::Node node);
 
       /// Read a scalar value from a `YAML::Node` path; searches all currently loaded config files.
       /// @param node_path the `YAML::Node` path
-      /// @return the scalar
+      /// @return the scalar, if found
       template <typename SCALAR>
-      SCALAR GetScalar(node_path_t node_path);
+      std::optional<SCALAR> GetScalar(node_path_t node_path);
 
       /// Read a vector value from a `YAML::Node`
       /// @param node the `YAML::Node` to read
-      /// @return the vector
+      /// @return the vector, if found
       template <typename SCALAR>
-      std::vector<SCALAR> GetVector(YAML::Node node);
+      std::optional<std::vector<SCALAR>> GetVector(YAML::Node node);
 
       /// Read a vector value from a `YAML::Node` path; searches all currently loaded config files.
       /// @param node_path the `YAML::Node` path
-      /// @return the vector
+      /// @return the vector, if found
       template <typename SCALAR>
-      std::vector<SCALAR> GetVector(node_path_t node_path);
+      std::optional<std::vector<SCALAR>> GetVector(node_path_t node_path);
 
       /// Create a function to search a `YAML::Node` for a sub-`YAML::Node` such that
       /// the scalar `val` is within a range specified by `key`


### PR DESCRIPTION
This allows an algorithm's YAML configuration to control the log level; `SetOption("log",...)` still takes the highest priority. For example:
```yaml
clas12::SomeAlgorithm:
  log: trace
```