### PR TITLE
fix: disable coverage test until fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,19 +430,19 @@ jobs:
           done
           iguana_src/.github/make-benchmark-table.rb benchmark_{single_threaded,memoize}.txt | xargs -0 -I{} echo {} >> $GITHUB_STEP_SUMMARY
       ### coverage
-      - name: coverage
-        if: ${{ matrix.id == 'coverage' }}
-        run: |
-          ninja -C iguana_build coverage-html
-          ninja -C iguana_build coverage-text
-          mv iguana_build/meson-logs/coveragereport coverage-report
-          echo '### Coverage Report' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat iguana_build/meson-logs/coverage.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '- for details, see the `coverage-report` artifact' >> $GITHUB_STEP_SUMMARY
-          echo '- to compare to the report from the `main` branch, see <https://jeffersonlab.github.io/iguana/coverage-report>' >> $GITHUB_STEP_SUMMARY
+      # - name: coverage
+      #   if: ${{ matrix.id == 'coverage' }}
+      #   run: |
+      #     ninja -C iguana_build coverage-html
+      #     ninja -C iguana_build coverage-text
+      #     mv iguana_build/meson-logs/coveragereport coverage-report
+      #     echo '### Coverage Report' >> $GITHUB_STEP_SUMMARY
+      #     echo '```' >> $GITHUB_STEP_SUMMARY
+      #     cat iguana_build/meson-logs/coverage.txt >> $GITHUB_STEP_SUMMARY
+      #     echo '```' >> $GITHUB_STEP_SUMMARY
+      #     echo '' >> $GITHUB_STEP_SUMMARY
+      #     echo '- for details, see the `coverage-report` artifact' >> $GITHUB_STEP_SUMMARY
+      #     echo '- to compare to the report from the `main` branch, see <https://jeffersonlab.github.io/iguana/coverage-report>' >> $GITHUB_STEP_SUMMARY
       ### test relocatability
       - name: test relocatability
         run: |
@@ -510,13 +510,13 @@ jobs:
           name: meson_logs_${{ matrix.id }}
           retention-days: 5
           path: iguana_build/meson-logs
-      - name: upload coverage artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ matrix.id == 'coverage' }}
-        with:
-          name: coverage-report
-          retention-days: 5
-          path: coverage-report
+      # - name: upload coverage artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: ${{ matrix.id == 'coverage' }}
+      #   with:
+      #     name: coverage-report
+      #     retention-days: 5
+      #     path: coverage-report
       - name: upload validator artifacts
         uses: actions/upload-artifact@v4
         if: ${{ matrix.id == 'cpp' }}
@@ -550,18 +550,18 @@ jobs:
         with:
           name: doc_doxygen
           path: doxygen
-      - name: download coverage report
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage-report
+      # - name: download coverage report
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: coverage-report
+      #     path: coverage-report
       - run: tree
       - name: collect
         run: |
           mkdir pages
           cp iguana_src/.github/pages-index.html pages/index.html
           mv doxygen pages/
-          mv coverage-report pages/
+      # - run: mv coverage-report pages/
       - run: tree
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Failing coverage tests have been preventing the documentation from being regenerated; disabling coverage testing until #282 is fixed.