### PR TITLE
fix: suppress all `hipo::structure` UBSan alignment errors

### DIFF
--- a/meson/ubsan.supp
+++ b/meson/ubsan.supp
@@ -1,6 +1,16 @@
 # https://github.com/gavalian/hipo/issues/49
-alignment:hipo::structure::getFloatAt
+alignment:hipo::structure::getIntAt
 alignment:hipo::structure::getShortAt
+alignment:hipo::structure::getByteAt
+alignment:hipo::structure::getFloatAt
 alignment:hipo::structure::getDoubleAt
-alignment:hipo::structure::putDoubleAt
+alignment:hipo::structure::getLongAt
+alignment:hipo::structure::getStringAt
+
 alignment:hipo::structure::putIntAt
+alignment:hipo::structure::putShortAt
+alignment:hipo::structure::putByteAt
+alignment:hipo::structure::putFloatAt
+alignment:hipo::structure::putDoubleAt
+alignment:hipo::structure::putLongAt
+alignment:hipo::structure::putStringAt


### PR DESCRIPTION
See https://github.com/gavalian/hipo/issues/49