### PR TITLE
build: use static project version number

### DIFF
--- a/doc/maintenance.md
+++ b/doc/maintenance.md
@@ -4,14 +4,7 @@ Notes for `iguana` maintainers
 
 ## Iguana version
 
-The `iguana` version is dynamically determined from the most recent `git` tag in the commit graph:
-
-- [`meson/detect-version.sh`](/meson/detect-version.sh)
-
-This will _only_ work if the source tree includes `.git/`, with tags and history including the most recent tag.
-If the source code was obtained from a release tarball from GitHub, the `.git/` directory will be absent and version detection will fail.
-
-Because of the fragility of version detection, we try to keep at least the _major_ version correct in the fallback version number of the version detection implementation.
+Please remember to bump to the version number in [`meson.build`](/meson.build) prior to tagging a new release.
 
 ## Python Binding Dependencies
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project(
   'iguana',
   'cpp',
+  version: '0.8.0',
   license: [ 'LGPLv3' ],
   license_files: [ 'LICENSE' ],
   meson_version: '>=1.2',
@@ -12,11 +13,6 @@ project(
     'pkgconfig.relocatable': 'true',
     'force_fallback_for': ['rcdb'],
   },
-  version: run_command(
-    meson.project_source_root() / 'meson' / 'detect-version.sh',
-    meson.project_source_root(),
-    check: true,
-  ).stdout().strip(),
 )
 project_description = 'Implementation Guardian of Analysis Algorithms'
 

--- a/meson/detect-version.sh
+++ b/meson/detect-version.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# detect the version number from the latest git tag
-set -e
-[ $# -ne 1 ] && echo "USAGE: $0 [GIT_REPO]" >&2 && exit 2
-cd $1
-version=$(git describe --tags --abbrev=0 || echo '0.0.0')
-echo $version | sed 's;^v;;'

--- a/meson/release/install-cvmfs.sh
+++ b/meson/release/install-cvmfs.sh
@@ -28,8 +28,6 @@ CMAKE_PREFIX_PATH:
 }
 
 sourceDir=$(realpath $(dirname ${BASH_SOURCE[0]:-$0})/../..)
-version=$($sourceDir/meson/detect-version.sh $sourceDir)
-msg "Detected version $version"
 
 if [ $# -ne 3 ]; then
   echo """


### PR DESCRIPTION
We've been using `detect-version.sh` to automatically get the version number from the most recent `git` tag, but this relies on the `git` metadata being available at build time. Since this may not always be true, especially in deployment / release builds, we want to avoid the situation of deploying `iguana.pc` with an unknown version number. We thus switch to using a static version number instead.

The only drawback is that we now need to remember to bump the version number prior to a release.