### PR TITLE
fix(build): bump `hipopy` requirement, since CMake v4 has been released

### DIFF
--- a/bind/python/requirements.txt
+++ b/bind/python/requirements.txt
@@ -3,4 +3,4 @@ cppyy-backend==1.15.2
 cppyy-cling==6.30.0
 CPyCppyy==1.12.16
 pkgconfig==1.5.5
-hipopy==1.3.3
+hipopy==1.3.6


### PR DESCRIPTION
fixes https://github.com/JeffersonLab/iguana/issues/337

respects https://github.com/mfmceneaney/hipopybind/issues/3