### PR TITLE
doc(ci): use Ubuntu runner, not container image, for downloading test data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   download_test_data:
     name: Download test data
     runs-on: ubuntu-latest
-    # NOTE: using Ubuntu runner, rather than a `container-forge` image, since there were problems accessing the cache
+    # NOTE: using Ubuntu runner, rather than a `container-forge` image, since it's much faster for cache hits
     steps:
       - uses: actions/cache@v4
         id: cache


### PR DESCRIPTION

When the cache hits (which is pretty much always), it's much faster to just use the runner, rather than wait for the container image pull. The job will be about 4 seconds, rather than 1-3 minutes.