### PR TITLE
doc: explain why `SectorFinder` operates on all particles, and not just filtered particles

### DIFF
--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
@@ -98,7 +98,7 @@ namespace iguana::clas12 {
     }
 
 
-    for(int row = 0; row < particleBank.getRows(); row++) {
+    for(auto const& row : particleBank.getRowList()) {
       int charge=particleBank.getInt("charge",row);
 
       bool userSp = charge==0 ? userSpecifiedBank_uncharged : userSpecifiedBank_charged;

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
@@ -98,7 +98,9 @@ namespace iguana::clas12 {
     }
 
 
-    for(auto const& row : particleBank.getRowList()) {
+    // some downstream algorithms may still need sector info, so obtain sector for _all_ particles,
+    // not just the ones that were filtered out (use `.getRows()` rather than `.getRowList()`)
+    for(int row = 0; row < particleBank.getRows(); row++) {
       int charge=particleBank.getInt("charge",row);
 
       bool userSp = charge==0 ? userSpecifiedBank_uncharged : userSpecifiedBank_charged;

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -16,7 +16,7 @@ namespace iguana::clas12 {
   /// @config_param{bank_uncharged | string | if not `default`, use this bank for sector finding of neutral particles}
   /// @end_doc
   ///
-  /// Rows that have been filtered out of `REC::Particle` will be zeroed in `REC::Particle::Sector`.
+  /// Rows that have been filtered out of `REC::Particle` will still have their sectors determined.
   ///
   /// @creator_note
   class SectorFinder : public Algorithm

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.h
@@ -16,6 +16,8 @@ namespace iguana::clas12 {
   /// @config_param{bank_uncharged | string | if not `default`, use this bank for sector finding of neutral particles}
   /// @end_doc
   ///
+  /// Rows that have been filtered out of `REC::Particle` will be zeroed in `REC::Particle::Sector`.
+  ///
   /// @creator_note
   class SectorFinder : public Algorithm
   {


### PR DESCRIPTION
Some downstream algorithms may still need sector info, so obtain sector for _all_ particles, not just the ones that were filtered out (use `.getRows()` rather than `.getRowList()`)
