### PR TITLE
fix(this_iguana.sh): prioritize Iguana in all path-type env vars

### DIFF
--- a/bind/python/meson.build
+++ b/bind/python/meson.build
@@ -1,7 +1,4 @@
-pythondir = 'python'
-project_pkg_vars += 'pythonpath=' + '${prefix}' / pythondir
-
-install_subdir('pyiguana', install_dir: pythondir)
+install_subdir('pyiguana', install_dir: project_pythondir)
 
 if (get_option('install_examples'))
   python_examples = [

--- a/doc/gen/mainpage.md
+++ b/doc/gen/mainpage.md
@@ -286,6 +286,6 @@ export IGUANA_CONFIG_PATH=`pwd`/my_iguana_config:$IGUANA_CONFIG_PATH   # bash or
 setenv IGUANA_CONFIG_PATH `pwd`/my_iguana_config:$IGUANA_CONFIG_PATH   # tcsh or csh
 ```
 The algorithms will then search `my_iguana_config` for the configuration before searching the default paths. You may add multiple paths, if needed.
-Paths which appear first in `$IGUANA_CONFIG_PATH` will be prioritized when the algorithm searches for configuration parameters; this behavior is similar to that of `$PATH` or `$LD_LIBRARY_PATH`.
+Paths which appear first in `$IGUANA_CONFIG_PATH` will be prioritized when the algorithm searches for configuration parameters; this behavior is similar to that of `$PATH` or `$LD_LIBRARY_PATH`. Note that `source this_iguana.sh` will _overwrite_ `$IGUANA_CONFIG_PATH`.
 
 2. Use `iguana::Algorithm::SetConfigDirectory` instead of prepending `$IGUANA_CONFIG_PATH` (and if you use an algorithm sequence, use `iguana::AlgorithmSequence::SetConfigDirectoryForEachAlgorithm`)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,5 +1,5 @@
 # install config files
-example_config_files_prefix = project_etc / 'examples'
+example_config_files_prefix = project_etcdir / 'examples'
 install_subdir('config', install_dir: example_config_files_prefix, strip_directory: true)
 
 # example source information

--- a/meson.build
+++ b/meson.build
@@ -175,14 +175,9 @@ endif
 project_inc = include_directories('src')
 project_libs = []
 project_deps = declare_dependency(dependencies: dep_list) # do NOT include ROOT here
-project_etc = get_option('sysconfdir') / meson.project_name()
+project_etcdir = get_option('sysconfdir') / meson.project_name()
 project_test_env = environment()
-project_pkg_vars = [
-  'bindir='            + '${prefix}' / get_option('bindir'),
-  'dep_pkgconfigdirs=' + ':'.join(dep_pkgconfig_dirs),
-  'dep_libdirs='       + ':'.join(dep_lib_dirs),
-  'dep_includedirs='   + ':'.join(dep_include_dirs),
-]
+project_pythondir = 'python'
 
 # sanitizer settings
 project_test_env.set(
@@ -207,7 +202,7 @@ project_test_env.set(
 
 # set preprocessor macros
 add_project_arguments(
-  '-DIGUANA_ETCDIR="' + get_option('prefix') / project_etc + '"',
+  '-DIGUANA_ETCDIR="' + get_option('prefix') / project_etcdir + '"',
   language: [ 'cpp' ],
 )
 
@@ -241,18 +236,11 @@ if get_option('install_documentation')
 endif
 
 # generate pkg-config file
-project_pkg_vars_nonempty = []
-foreach var : project_pkg_vars
-  if not var.endswith('=') # remove empty variable values
-    project_pkg_vars_nonempty += var
-  endif
-endforeach
 pkg.generate(
   name: meson.project_name(),
   description: project_description,
   libraries: project_libs,
   requires: [ fmt_dep, yamlcpp_dep, hipo_dep ], # pkg-config dependencies only
-  variables: project_pkg_vars_nonempty,
 )
 
 # install environment setup files
@@ -263,11 +251,17 @@ if get_option('z_install_envfile')
     install: true,
     install_dir: get_option('bindir'),
     configuration: {
-      'ld_path': host_machine.system() != 'darwin' ? 'LD_LIBRARY_PATH' : 'DYLD_LIBRARY_PATH',
-      'python': get_option('bind_python') ? 'true' : 'false',
-      'libdir': get_option('libdir'),
-      'root': ROOT_dep.found() ? 'true' : 'false',
-      'etcdir': project_etc,
+      'ld_path':           host_machine.system() != 'darwin' ? 'LD_LIBRARY_PATH' : 'DYLD_LIBRARY_PATH',
+      'python':            get_option('bind_python') ? 'true' : 'false',
+      'root':              ROOT_dep.found() ? 'true' : 'false',
+      'libdir':            get_option('libdir'),
+      'includedir':        get_option('includedir'),
+      'bindir':            get_option('bindir'),
+      'etcdir':            project_etcdir,
+      'pythondir':         project_pythondir,
+      'dep_pkgconfigdirs': ':'.join(dep_pkgconfig_dirs),
+      'dep_libdirs':       ':'.join(dep_lib_dirs),
+      'dep_includedirs':   ':'.join(dep_include_dirs),
     },
   )
   foreach shell : [ 'csh', 'tcsh' ]

--- a/meson/this_iguana.sh.in
+++ b/meson/this_iguana.sh.in
@@ -3,10 +3,12 @@
 
 # parse arguments
 arg_verbose=false
+arg_allow_deps=true
 arg_githubCI=false
 for arg in "$@"; do
   case $arg in
     --verbose) arg_verbose=true ;;
+    --no-deps) arg_allow_deps=false ;;
     --githubCI) arg_githubCI=true ;;
     --help|-h)
       echo "USAGE: source ${BASH_SOURCE[0]:-$0} [OPTIONS]..." >&2
@@ -14,11 +16,12 @@ for arg in "$@"; do
       OPTIONS:
 
         --verbose     print what variables are set
-
+        --no-deps     do not include dependencies in path-type variables
         --githubCI    set environment for GitHub CI
       """ >&2
       unset arg
       unset arg_verbose
+      unset arg_allow_deps
       unset arg_githubCI
       return 2
       ;;
@@ -28,6 +31,7 @@ for arg in "$@"; do
       echo "ERROR: unknown option '$arg'" >&2
       unset arg
       unset arg_verbose
+      unset arg_allow_deps
       unset arg_githubCI
       return 1
       ;;
@@ -35,57 +39,36 @@ for arg in "$@"; do
 done
 unset arg
 
-# workaround older versions of macOS not having `realpath`
-get_realpath() {
-  echo $(cd $1 && pwd -P)
-}
+# set IGUANA prefix; use `cd && pwd` to support older macOS versions
+export IGUANA=$(cd $(dirname ${BASH_SOURCE[0]:-$0})/.. && pwd -P)
 
-# set IGUANA prefix
-export IGUANA=$(get_realpath $(dirname ${BASH_SOURCE[0]:-$0})/..)
+# if allowing dependencies in the environment, prepend their paths
+## FIXME: this won't work well if a user already has all dependency libraries
+## in, for example, `/opt/lib`, but has custom built and installed one
+## elsewhere, e.g., `/tmp/lib`; if `/opt/lib` is listed before `/tmp/lib` in
+## `$LD_LIBRARY_PATH`, the `/opt/lib` library will be used at runtime rather
+## than the one at `/tmp/lib` (cf. FIXME in ../meson.build)
+if $arg_allow_deps; then
+  export PKG_CONFIG_PATH=@dep_pkgconfigdirs@${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
+  export @ld_path@=@dep_libdirs@${@ld_path@:+:${@ld_path@}}
+  if @root@; then
+    export ROOT_INCLUDE_PATH=@dep_includedirs@${ROOT_INCLUDE_PATH:+:${ROOT_INCLUDE_PATH}}
+  fi
+fi
 
-# prepend to PKG_CONFIG_PATH
+# prepend paths with iguana
 export PKG_CONFIG_PATH=$IGUANA/@libdir@/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
-dep_pkgconfigdirs=$(pkg-config --variable dep_pkgconfigdirs iguana)
-[ -n "${dep_pkgconfigdirs-}" ] && export PKG_CONFIG_PATH=$dep_pkgconfigdirs${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
-unset dep_pkgconfigdirs
-
-# prepend to PATH
-iguana_path=$(pkg-config --variable bindir iguana)
-[ -n "${iguana_path-}" ] && export PATH=$(get_realpath $iguana_path)${PATH:+:${PATH}}
-unset iguana_path
-
-# prepend to PYTHONPATH
+export PATH=$IGUANA/@bindir@${PATH:+:${PATH}}
+export @ld_path@=$IGUANA/@libdir@${@ld_path@:+:${@ld_path@}}
 if @python@; then
-  iguana_pythonpath=$(pkg-config --variable pythonpath iguana)
-  [ -n "${iguana_pythonpath-}" ] && export PYTHONPATH=$iguana_pythonpath${PYTHONPATH:+:${PYTHONPATH}}
-  unset iguana_pythonpath
+  export PYTHONPATH=$IGUANA/@pythondir@${PYTHONPATH:+:${PYTHONPATH}}
 fi
-
-# prepend to LD_LIBRARY_PATH or DYLD_LIBRARY_PATH
-# FIXME: this won't work well if a user already has all dependency libraries
-# in, for example, `/opt/lib`, but has custom built and installed one
-# elsewhere, e.g., `/tmp/lib`; if `/opt/lib` is listed before `/tmp/lib` in
-# `$LD_LIBRARY_PATH`, the `/opt/lib` library will be used at runtime rather
-# than the one at `/tmp/lib` (cf. FIXME in ../meson.build)
-for var in dep_libdirs libdir; do
-  dir=$(pkg-config --variable $var iguana)
-  [ -n "${dir-}" ] && export @ld_path@=$dir${@ld_path@:+:${@ld_path@}}
-  unset dir
-done
-unset var
-
-# prepend to ROOT_INCLUDE_PATH
 if @root@; then
-  for var in dep_includedirs includedir; do
-    dir=$(pkg-config --variable $var iguana)
-    [ -n "${dir-}" ] && export ROOT_INCLUDE_PATH=$dir${ROOT_INCLUDE_PATH:+:${ROOT_INCLUDE_PATH}}
-    unset dir
-  done
-  unset var
+  export ROOT_INCLUDE_PATH=$IGUANA/@includedir@${ROOT_INCLUDE_PATH:+:${ROOT_INCLUDE_PATH}}
 fi
 
-# set config file path; append, rather than prepend, in case the user already has their own
-export IGUANA_CONFIG_PATH=${IGUANA_CONFIG_PATH:+${IGUANA_CONFIG_PATH}:}$IGUANA/@etcdir@
+# set config file path
+export IGUANA_CONFIG_PATH=$IGUANA/@etcdir@
 
 # print environment variables
 if $arg_verbose; then
@@ -106,13 +89,13 @@ PATH -- ADDED iguana executables:
 @ld_path@ -- ADDED iguana and dependency library paths:
   $(print_var ${@ld_path@-})
 
-ROOT_INCLUDE_PATH -- $(if @root@; then echo 'ADDED iguana and dependency include paths:'; else echo 'has NOT been changed'; fi)
+ROOT_INCLUDE_PATH -- $(if @root@; then echo 'ADDED iguana and dependency include paths:'; else echo 'has NOT been changed, since not built with ROOT support'; fi)
   $(print_var ${ROOT_INCLUDE_PATH-})
 
-PYTHONPATH -- $(if @python@; then echo 'ADDED iguana python bindings:'; else echo 'has NOT been changed'; fi)
+PYTHONPATH -- $(if @python@; then echo 'ADDED iguana python bindings:'; else echo 'has NOT been changed, since not built with Python support'; fi)
   $(print_var ${PYTHONPATH-})
 
-IGUANA_CONFIG_PATH -- ADDED iguana algorithms' default configuration directory
+IGUANA_CONFIG_PATH -- SET to iguana algorithms' default configuration directory
   $(print_var ${IGUANA_CONFIG_PATH-})
 
 ----------------------------
@@ -136,5 +119,5 @@ fi
 
 # cleanup
 unset arg_verbose
+unset arg_allow_deps
 unset arg_githubCI
-unset -f get_realpath

--- a/meson/this_iguana.sh.in
+++ b/meson/this_iguana.sh.in
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
-# `source` this file to set environment variables relevant for this `iguana` installation
+##################################################################################
+# `source` this file to set run-time environment variables such as `$@ld_path@`
+# - you only need to `source` this file if you are not installing `iguana` to a
+#   common prefix; alternatively, set your own run-time environment variables
+# - run `source this_iguana.sh --help` for more options
+##################################################################################
 
 # parse arguments
-arg_verbose=false
-arg_allow_deps=true
-arg_githubCI=false
+declare -A args
+args['verbose']=false
+args['allow_deps']=true
+args['githubCI']=false
 for arg in "$@"; do
   case $arg in
-    --verbose) arg_verbose=true ;;
-    --no-deps) arg_allow_deps=false ;;
-    --githubCI) arg_githubCI=true ;;
+    --verbose) args['verbose']=true ;;
+    --no-deps) args['allow_deps']=false ;;
+    --githubCI) args['githubCI']=true ;;
     --help|-h)
       echo "USAGE: source ${BASH_SOURCE[0]:-$0} [OPTIONS]..." >&2
       echo """
@@ -19,25 +25,55 @@ for arg in "$@"; do
         --no-deps     do not include dependencies in path-type variables
         --githubCI    set environment for GitHub CI
       """ >&2
-      unset arg
-      unset arg_verbose
-      unset arg_allow_deps
-      unset arg_githubCI
+      unset arg args
       return 2
       ;;
     source*|.*) # handle callers which cause `$1` to be 'source this_iguana.sh' or '. this_iguana.sh'
       ;;
     *)
       echo "ERROR: unknown option '$arg'" >&2
-      unset arg
-      unset arg_verbose
-      unset arg_allow_deps
-      unset arg_githubCI
+      unset arg args
       return 1
       ;;
   esac
 done
 unset arg
+
+##################################################################################
+
+# print environment
+print_environ() {
+  print_path() { echo "$@" | sed 's/:/\n  /g'; }
+  echo """---
+IGUANA: $IGUANA
+PKG_CONFIG_PATH: (
+  $(print_path ${PKG_CONFIG_PATH-})
+)
+PATH: (
+  $(print_path ${PATH-})
+)
+@ld_path@: (
+  $(print_path ${@ld_path@-})
+)
+ROOT_INCLUDE_PATH: (
+  $(print_path ${ROOT_INCLUDE_PATH-})
+)
+PYTHONPATH: (
+  $(print_path ${PYTHONPATH-})
+)
+IGUANA_CONFIG_PATH: (
+  $(print_path ${IGUANA_CONFIG_PATH-})
+)
+---"""
+  unset -f print_path
+}
+
+if ${args['verbose']}; then
+  echo 'Environment before `source`:'
+  print_environ
+fi
+
+##################################################################################
 
 # set IGUANA prefix; use `cd && pwd` to support older macOS versions
 export IGUANA=$(cd $(dirname ${BASH_SOURCE[0]:-$0})/.. && pwd -P)
@@ -48,7 +84,7 @@ export IGUANA=$(cd $(dirname ${BASH_SOURCE[0]:-$0})/.. && pwd -P)
 ## elsewhere, e.g., `/tmp/lib`; if `/opt/lib` is listed before `/tmp/lib` in
 ## `$LD_LIBRARY_PATH`, the `/opt/lib` library will be used at runtime rather
 ## than the one at `/tmp/lib` (cf. FIXME in ../meson.build)
-if $arg_allow_deps; then
+if ${args['allow_deps']}; then
   export PKG_CONFIG_PATH=@dep_pkgconfigdirs@${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
   export @ld_path@=@dep_libdirs@${@ld_path@:+:${@ld_path@}}
   if @root@; then
@@ -60,51 +96,44 @@ fi
 export PKG_CONFIG_PATH=$IGUANA/@libdir@/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}
 export PATH=$IGUANA/@bindir@${PATH:+:${PATH}}
 export @ld_path@=$IGUANA/@libdir@${@ld_path@:+:${@ld_path@}}
-if @python@; then
-  export PYTHONPATH=$IGUANA/@pythondir@${PYTHONPATH:+:${PYTHONPATH}}
-fi
 if @root@; then
   export ROOT_INCLUDE_PATH=$IGUANA/@includedir@${ROOT_INCLUDE_PATH:+:${ROOT_INCLUDE_PATH}}
+fi
+if @python@; then
+  export PYTHONPATH=$IGUANA/@pythondir@${PYTHONPATH:+:${PYTHONPATH}}
 fi
 
 # set config file path
 export IGUANA_CONFIG_PATH=$IGUANA/@etcdir@
 
+##################################################################################
+
+# enforce uniqueness in path-type variables
+uniq_path() {
+  echo $(awk -v RS=':' '!a[$1]++' <<< "$1" | paste -sd: | sed 's;^:;;' | sed 's;:$;;')
+}
+export PKG_CONFIG_PATH=$(uniq_path $PKG_CONFIG_PATH)
+export PATH=$(uniq_path $PATH)
+export @ld_path@=$(uniq_path $@ld_path@)
+if @root@; then
+  export ROOT_INCLUDE_PATH=$(uniq_path $ROOT_INCLUDE_PATH)
+fi
+if @python@; then
+  export PYTHONPATH=$(uniq_path $PYTHONPATH)
+fi
+export IGUANA_CONFIG_PATH=$(uniq_path $IGUANA_CONFIG_PATH)
+unset -f uniq_path
+
+##################################################################################
+
 # print environment variables
-if $arg_verbose; then
-  print_var() { echo "$@" | sed 's/:/\n  /g'; }
-  echo """
-Iguana Environment Variables
-----------------------------
-
-IGUANA -- SET
-  $IGUANA
-
-PKG_CONFIG_PATH -- ADDED iguana and dependency pkg-config paths:
-  $(print_var ${PKG_CONFIG_PATH-})
-
-PATH -- ADDED iguana executables:
-  $(print_var ${PATH-})
-
-@ld_path@ -- ADDED iguana and dependency library paths:
-  $(print_var ${@ld_path@-})
-
-ROOT_INCLUDE_PATH -- $(if @root@; then echo 'ADDED iguana and dependency include paths:'; else echo 'has NOT been changed, since not built with ROOT support'; fi)
-  $(print_var ${ROOT_INCLUDE_PATH-})
-
-PYTHONPATH -- $(if @python@; then echo 'ADDED iguana python bindings:'; else echo 'has NOT been changed, since not built with Python support'; fi)
-  $(print_var ${PYTHONPATH-})
-
-IGUANA_CONFIG_PATH -- SET to iguana algorithms' default configuration directory
-  $(print_var ${IGUANA_CONFIG_PATH-})
-
-----------------------------
-"""
-  unset -f print_var
+if ${args['verbose']}; then
+  echo 'Environment after `source`:'
+  print_environ
 fi
 
 # export variables for GitHub CI environment
-if $arg_githubCI; then
+if ${args['githubCI']}; then
   echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH >> $GITHUB_ENV
   echo PATH=$PATH >> $GITHUB_ENV
   echo @ld_path@=$@ld_path@ >> $GITHUB_ENV
@@ -118,6 +147,5 @@ if $arg_githubCI; then
 fi
 
 # cleanup
-unset arg_verbose
-unset arg_allow_deps
-unset arg_githubCI
+unset -v args
+unset -f print_environ

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -226,5 +226,5 @@ install_headers(vdor_headers, subdir: meson.project_name() / 'algorithms', prese
 
 # install config files
 foreach algo_config : algo_configs
-  install_data(algo_config, install_dir: project_etc / 'algorithms', preserve_path: true)
+  install_data(algo_config, install_dir: project_etcdir / 'algorithms', preserve_path: true)
 endforeach

--- a/src/iguana/bankdefs/meson.build
+++ b/src/iguana/bankdefs/meson.build
@@ -17,4 +17,4 @@ bankdef_tgt = custom_target(
 )
 
 # install the JSON data model file; iguana won't need it, but it can be useful for user reference
-install_data(bankdef_json, install_dir: project_etc / 'bankdefs' / 'hipo4')
+install_data(bankdef_json, install_dir: project_etcdir / 'bankdefs' / 'hipo4')


### PR DESCRIPTION
- fixes the case when there's another `iguana.pc` in `$PKG_CONFIG_PATH`, it was prioritizing that one
- `this_iguana.sh` now _overwrites_ the `$IGUANA_PREFIX_PATH`
  - previous behavior appends, which does not allow `this_iguana.sh` to override some other (container) Iguana installation
- removes additional variables from `iguana.pc`, since nowadays we use (but not rely on) environment variable `$IGUANA`
  - internally `$IGUANA` is not used, but we've been asked to provide it for consumers
- `this_iguana.sh` now _optionally_ includes dependency paths in path-type environment variables
  - including them can be convenient at runtime, but also can be annoying in many cases
  - let's make it optional for now, with the default keeping them included (no potentially breaking change)