### PR TITLE
fix: remove cross check warnings for cross-checked algorithms

### DIFF
--- a/src/iguana/algorithms/physics/Depolarization/Algorithm.cc
+++ b/src/iguana/algorithms/physics/Depolarization/Algorithm.cc
@@ -16,8 +16,6 @@ namespace iguana::physics {
     i_C       = result_schema.getEntryOrder("C");
     i_V       = result_schema.getEntryOrder("V");
     i_W       = result_schema.getEntryOrder("W");
-
-    m_log->Warn("the kinematic calculations in this algorithm need to be cross checked; use this algorithm at your own risk!");
   }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/iguana/algorithms/physics/DihadronKinematics/Algorithm.cc
+++ b/src/iguana/algorithms/physics/DihadronKinematics/Algorithm.cc
@@ -46,8 +46,6 @@ namespace iguana::physics {
       m_theta_method = e_hadron_a;
     else
       throw std::runtime_error(fmt::format("unknown theta_method: {:?}", o_theta_method));
-
-    m_log->Warn("the kinematic calculations in this algorithm need to be cross checked; use this algorithm at your own risk!");
   }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/iguana/algorithms/physics/InclusiveKinematics/Algorithm.cc
+++ b/src/iguana/algorithms/physics/InclusiveKinematics/Algorithm.cc
@@ -70,8 +70,6 @@ namespace iguana::physics {
       m_log->Error("Unknown beam particle {:?}", beam_particle);
       throw std::runtime_error("Start failed");
     }
-
-    m_log->Warn("the kinematic calculations in this algorithm need to be cross checked; use this algorithm at your own risk!");
   }
 
   ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I have cross checked these algorithms against my old dihadron analysis code, which has been cross checked with both Timothy Hayward and Gregory Matousek. The kinematics distributions and effects of event selection criteria are exactly the same.

I did not cross check `SingleHadronKinematics` yet, so that warning stays for now.