### PR TITLE
build: streamline ROOT dependency handling

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -26,12 +26,10 @@ foreach example, info : example_sources
     example_exe = executable(
       example,
       sources: info['sources'],
-      include_directories: [ project_inc ] + ROOT_dep_inc_dirs,
+      include_directories: [ project_inc ],
       dependencies: project_deps,
       link_with: project_libs,
-      link_args: ROOT_dep_link_args + ROOT_dep_link_args_for_validators,
       install: true,
-      build_rpath: ROOT_dep_rpath,
     )
     if fs.is_file(get_option('test_data_file'))
       test(

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ hipo_dep = dependency(
 )
 ROOT_dep = dependency(
   'ROOT',
-  version: '>=6.28.10',
+  version: '>=6.30',
   method: 'cmake',
   required: get_option('z_require_root'),
   modules: [

--- a/meson.build
+++ b/meson.build
@@ -61,6 +61,16 @@ ROOT_dep = dependency(
   version: '>=6.28.10',
   method: 'cmake',
   required: get_option('z_require_root'),
+  modules: [
+    'ROOT::Core',
+    'ROOT::GenVector',
+    'ROOT::Gpad',
+    'ROOT::Hist',
+    'ROOT::RIO',
+    'ROOT::ROOTDataFrame',
+    'ROOT::ROOTVecOps',
+    'ROOT::TreePlayer',
+  ],
 )
 prog_ruby = find_program(
   'ruby',
@@ -81,9 +91,8 @@ thread_dep = dependency(
 # FIXME: for users which use LD_LIBRARY_PATH, we should try to keep this list
 # ordered such that the ones users are *least likely* to try to build
 # themselves are listed last (see FIXME in meson/this_iguana.sh.in)
-# NOTE: omit ROOT (handled differently, and most ROOT users already have it in their environment)
 dep_list = []
-foreach dep : [ hipo_dep, fmt_dep, yamlcpp_dep, rcdb_dep ]
+foreach dep : [ hipo_dep, fmt_dep, yamlcpp_dep, rcdb_dep, ROOT_dep ]
   if dep.found()
     dep_list += dep
   endif
@@ -104,7 +113,7 @@ foreach dep : dep_list
     foreach lib : dep.get_variable(cmake: 'PACKAGE_LIBRARIES').split(';')
       libdirs += run_command('dirname', lib, check: true).stdout().strip()
     endforeach
-    incdirs = ROOT_dep.get_variable(cmake: 'PACKAGE_INCLUDE_DIRS').split(';')
+    incdirs = dep.get_variable(cmake: 'PACKAGE_INCLUDE_DIRS').split(';')
   else
     name = dep.get_variable(internal: 'name', default_value: dep.name())
     if name == 'rcdb'
@@ -140,41 +149,10 @@ hipo_dep_dataframes_found = hipo_dep.get_variable(
   default_value: 'false',
 ).to_lower() == 'true'
 
-# handle ROOT
-ROOT_dep_inc_dirs = []
-ROOT_dep_link_args = []
-ROOT_dep_link_args_for_validators = []
-ROOT_dep_rpath = ''
-if ROOT_dep.found()
-  ROOT_dep_inc_dirs += include_directories(
-    run_command('root-config', '--incdir', check: true).stdout().strip(),
-  )
-  ROOT_libdir = run_command('root-config', '--libdir', check: true).stdout().strip()
-  # ROOT libraries that we need (safer than `root-config --libs`)
-  ROOT_dep_link_args += [
-    '-L' + ROOT_libdir,
-    '-lCore',
-    '-lGenVector',
-    '-lROOTDataFrame',
-    '-lROOTVecOps',
-    '-lTreePlayer',
-  ]
-  # additional ROOT libraries for validators (namely, graphics libraries)
-  ROOT_dep_link_args_for_validators = [
-    '-L' + ROOT_libdir,
-    '-lRIO',
-    '-lHist',
-    '-lGpad',
-  ]
-  ROOT_dep_rpath = ROOT_libdir
-  # preprocessor macro for turning on/off ROOT-dependent parts of the code; currently only used for Validator plot styles
-  add_project_arguments('-DIGUANA_ROOT_FOUND', language: [ 'cpp' ])
-endif
-
 # general project vars
 project_inc = include_directories('src')
 project_libs = []
-project_deps = declare_dependency(dependencies: dep_list) # do NOT include ROOT here
+project_deps = declare_dependency(dependencies: dep_list)
 project_etcdir = get_option('sysconfdir') / meson.project_name()
 project_test_env = environment()
 project_pythondir = 'python'
@@ -201,10 +179,10 @@ project_test_env.set(
 )
 
 # set preprocessor macros
-add_project_arguments(
-  '-DIGUANA_ETCDIR="' + get_option('prefix') / project_etcdir + '"',
-  language: [ 'cpp' ],
-)
+add_project_arguments('-DIGUANA_ETCDIR="' + get_option('prefix') / project_etcdir + '"', language: [ 'cpp' ])
+if ROOT_dep.found()
+  add_project_arguments('-DIGUANA_ROOT_FOUND', language: [ 'cpp' ]) # currently only used for Validator plot styles
+endif
 
 # start chameleon
 if use_chameleon

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -220,12 +220,10 @@ endforeach
 algo_lib = shared_library(
   'IguanaAlgorithms',
   algo_sources,
-  include_directories: [ project_inc ] + ROOT_dep_inc_dirs,
+  include_directories: [ project_inc ],
   dependencies: project_deps,
   link_with: [ services_lib ],
-  link_args: ROOT_dep_link_args,
   install: true,
-  build_rpath: ROOT_dep_rpath,
 )
 install_headers(algo_headers, subdir: meson.project_name() / 'algorithms', preserve_path: true)
 project_libs += algo_lib
@@ -234,12 +232,10 @@ project_libs += algo_lib
 vdor_lib = shared_library(
   'IguanaValidators',
   vdor_sources,
-  include_directories: [ project_inc ] + ROOT_dep_inc_dirs,
+  include_directories: [ project_inc ],
   dependencies: project_deps,
   link_with: [ services_lib, algo_lib ],
-  link_args: ROOT_dep_link_args + ROOT_dep_link_args_for_validators,
   install: true,
-  build_rpath: ROOT_dep_rpath,
 )
 install_headers(vdor_headers, subdir: meson.project_name() / 'algorithms', preserve_path: true)
 

--- a/src/iguana/bindings/meson.build
+++ b/src/iguana/bindings/meson.build
@@ -6,12 +6,10 @@ if get_option('bind_fortran')
   algo_bind_c_lib = shared_library(
     'IguanaBindingsC',
     algo_bind_c_sources,
-    include_directories: [ project_inc ] + ROOT_dep_inc_dirs,
+    include_directories: [ project_inc ],
     dependencies: project_deps,
     link_with: [ services_lib, algo_lib ],
-    link_args: ROOT_dep_link_args + ROOT_dep_link_args_for_validators,
     install: true,
-    build_rpath: ROOT_dep_rpath,
   )
   project_libs += algo_bind_c_lib
 endif

--- a/src/iguana/tests/meson.build
+++ b/src/iguana/tests/meson.build
@@ -5,12 +5,10 @@ test_exe_links = project_libs + [ vdor_lib ]
 test_exe = executable(
   test_exe_name,
   test_exe_name + '.cc',
-  include_directories: [ test_exe_inc, project_inc ] + ROOT_dep_inc_dirs,
+  include_directories: [ test_exe_inc, project_inc ],
   dependencies: [ project_deps, thread_dep ],
   link_with: test_exe_links,
-  link_args: ROOT_dep_link_args,
   install: true,
-  build_rpath: ROOT_dep_rpath,
 )
 
 # test algorithms and validators

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,1 +1,2 @@
 /packagecache
+.wraplock


### PR DESCRIPTION
We are starting to see warnings such as
```
WARNING: Could not find and exact match for the CMake dependency ROOT.
However, Meson found the following partial matches:
    ['ROOT::Core', 'ROOT::vectorDict', 'ROOT::listDict', ...
Using imported is recommended, since this approach is less error prone
and better supported by Meson. Consider explicitly specifying one of
these in the dependency call with:
    dependency('ROOT', modules: ['ROOT::<name>', ...])
Meson will now continue to use the old-style ROOT_LIBRARIES CMake
variables to extract the dependency information since no explicit
target is currently specified.
```

Let's do what it says, since now we can just use the `dependency` object in functions like `shared_library`, rather than manually adding ROOT's libraries and headers.

Tested against ROOT 6.30 and 6.36.