### PR TITLE
proof of concept: inherit from another algorithm

### DIFF
--- a/src/iguana/algorithms/clas12/FiducialFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/FiducialFilter/Algorithm.h
@@ -154,13 +154,13 @@ namespace iguana::clas12 {
           float const torus,
           int const pid) const;
 
-    private: // methods
+    protected: // methods
 
       /// @param level the cut level string
       /// @returns `CutLevel` associated to the input
       CutLevel ParseCutLevel(std::string const& level) const;
 
-    private: // members
+    protected: // members
 
       // `hipo::banklist`
       hipo::banklist::size_type b_particle;

--- a/src/iguana/algorithms/clas12/rgc/FiducialFilter/Action.yaml
+++ b/src/iguana/algorithms/clas12/rgc/FiducialFilter/Action.yaml
@@ -1,0 +1,1 @@
+../../FiducialFilter/Action.yaml

--- a/src/iguana/algorithms/clas12/rgc/FiducialFilter/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/rgc/FiducialFilter/Algorithm.cc
@@ -1,0 +1,7 @@
+#include "Algorithm.h"
+
+namespace iguana::clas12::rgc {
+
+  REGISTER_IGUANA_ALGORITHM(FiducialFilter);
+
+}

--- a/src/iguana/algorithms/clas12/rgc/FiducialFilter/Algorithm.h
+++ b/src/iguana/algorithms/clas12/rgc/FiducialFilter/Algorithm.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "iguana/algorithms/clas12/FiducialFilter/Algorithm.h"
+
+namespace iguana::clas12::rgc {
+
+  /// @brief_algo Filter the `REC::Particle` bank by applying DC (drift chamber) and ECAL (electromagnetic calorimeter) fiducial cuts
+  ///
+  /// based on RG-A, with different config for RG-C
+  class FiducialFilter : public iguana::clas12::FiducialFilter
+  {
+
+      // use `DEFINE_IGUANA_ALGORITHM_IMPL` instead of `DEFINE_IGUANA_ALGORITHM`, since the direct base class is not `Algorithm`
+      DEFINE_IGUANA_ALGORITHM_IMPL(FiducialFilter, clas12::rgc::FiducialFilter, clas12::FiducialFilter)
+
+    public:
+      /*
+      void Start(hipo::banklist& banks) override;
+      void Run(hipo::banklist& banks) const override;
+      void Stop() override;
+      */
+
+  };
+
+}

--- a/src/iguana/algorithms/clas12/rgc/FiducialFilter/Config.yaml
+++ b/src/iguana/algorithms/clas12/rgc/FiducialFilter/Config.yaml
@@ -1,0 +1,10 @@
+clas12::rgc::FiducialFilter:
+  pass: 3
+
+  # cut levels for PCAL homogeneous cuts; one of 'loose', 'medium', or 'tight'
+  pcal_electron_cut_level: tight # for electrons and positrons
+  pcal_photon_cut_level: tight # for photons
+
+  # enable/disable certain cuts for more fine-grained control
+  enable_pcal_cuts: 1
+  enable_dc_cuts: 1

--- a/src/iguana/algorithms/meson.build
+++ b/src/iguana/algorithms/meson.build
@@ -44,6 +44,14 @@ algo_dict = [
     },
   },
   {
+    'name': 'clas12::rgc::FiducialFilter',
+    'has_validator': false, # FIXME
+    'test_args': {
+      'banks': [ 'REC::Particle', 'RUN::config', 'REC::Traj', 'REC::Calorimeter' ],
+      'prerequisites': [ 'clas12::CalorimeterLinker', 'clas12::TrajLinker' ],
+    },
+  },
+  {
     'name': 'clas12::SectorFinder',
     'test_args': {
       'banks': [ 'REC::Particle', 'REC::Calorimeter', 'REC::Track', 'REC::Scintillator' ],


### PR DESCRIPTION
The current `FiducialFilter` is for RG-A Pass 1. I am trying to come up with ways to handle algorithms that are not _quite_ run group independent. Suppose RG-C would like to use this algorithm, but with a _different_ configuration, and possibly add some additional cuts. One approach is to _inherit_ from `FiducialFilter`.

This PR tests this capability by creating an `rgc` namespace, and the algorithm `rgc::FiducialFilter`.

**do not merge**