### PR TITLE
feat: `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# global auto-formatting
+90fac1e71834c1082690c40217e081698b33c4e4 # chore: auto format (#117)
+f2e1d71bed7bf420696fec8acb6b4d8e8e489c82 # style: apply auto-format to C++ code (#378)


### PR DESCRIPTION
For ignoring certain commits in `git blame`, such as auto-formatting.