### PR TITLE
feat: improve event-level filter for SIDIS kinematics

### DIFF
--- a/src/iguana/algorithms/physics/DihadronKinematics/Algorithm.cc
+++ b/src/iguana/algorithms/physics/DihadronKinematics/Algorithm.cc
@@ -204,7 +204,7 @@ namespace iguana::physics {
     }
 
     ShowBank(result_bank, Logger::Header("CREATED BANK"));
-    return true;
+    return result_bank.getRows() > 0;
   }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/iguana/algorithms/physics/DihadronKinematics/Algorithm.h
+++ b/src/iguana/algorithms/physics/DihadronKinematics/Algorithm.h
@@ -47,7 +47,8 @@ namespace iguana::physics {
       /// @param [in] particle_bank `REC::Particle`
       /// @param [in] inc_kin_bank `%physics::InclusiveKinematics`, produced by the `physics::InclusiveKinematics` algorithm
       /// @param [out] result_bank `%physics::DihadronKinematics`, which will be created
-      /// @returns `false` if the input banks do not have enough information, _e.g._, if the inclusive kinematics bank is empty
+      /// @returns `false` if the input banks do not have enough information, _e.g._, if the inclusive kinematics bank is empty,
+      /// or if the created bank is empty
       bool Run(
           hipo::bank const& particle_bank,
           hipo::bank const& inc_kin_bank,

--- a/src/iguana/algorithms/physics/SingleHadronKinematics/Algorithm.cc
+++ b/src/iguana/algorithms/physics/SingleHadronKinematics/Algorithm.cc
@@ -168,7 +168,7 @@ namespace iguana::physics {
     result_bank.getMutableRowList().setList(result_bank_rowlist);
 
     ShowBank(result_bank, Logger::Header("CREATED BANK"));
-    return true;
+    return result_bank.getRows() > 0;
   }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/iguana/algorithms/physics/SingleHadronKinematics/Algorithm.h
+++ b/src/iguana/algorithms/physics/SingleHadronKinematics/Algorithm.h
@@ -36,7 +36,8 @@ namespace iguana::physics {
       /// @param [in] particle_bank `REC::Particle`
       /// @param [in] inc_kin_bank `%physics::InclusiveKinematics`, produced by the `physics::InclusiveKinematics` algorithm
       /// @param [out] result_bank `%physics::SingleHadronKinematics`, which will be created
-      /// @returns `false` if the input banks do not have enough information, _e.g._, if the inclusive kinematics bank is empty
+      /// @returns `false` if the input banks do not have enough information, _e.g._, if the inclusive kinematics bank is empty,
+      /// or if the created bank is empty
       bool Run(
           hipo::bank const& particle_bank,
           hipo::bank const& inc_kin_bank,


### PR DESCRIPTION
Their `Run` functions should return `false` if their created banks are empty.