### PR TITLE
fix: Update hipopy version.

### DIFF
--- a/bind/python/README.md
+++ b/bind/python/README.md
@@ -39,3 +39,6 @@ For Python to be able to find and use these bindings, you need to set some envir
 Example Python scripts are found in this directory as `iguana_ex_*.py`; they will be installed in the `bin/` subdirectory.
 
 Most of them are analogous to the C++ examples, but some may be specific to the Python bindings.
+
+> [!NOTE]
+> If you are using these bindings simultaneously with `hipopy>=2.0.0`, which in turn depends on `hipopybind>=2.0.1`, you must import `hipopy` **before** importing `pyiguana`.  This is due to a naming clash between duplicated linked hipo libraries since `hipopybind` hides linked symbols, but `cppyy` by default loads symbols globally.

--- a/bind/python/iguana_ex_python_hipopy.py
+++ b/bind/python/iguana_ex_python_hipopy.py
@@ -8,10 +8,10 @@
 @end_doc_example
 @doxygen_off
 """
-
+#NOTE: You must import hipopy, which imports hipopybind, BEFORE any cppyy libraries.
+import hipopy.hipopy as hp
 import pyiguana
 import sys
-import hipopy.hipopy as hp
 import os.path as osp
 
 # include the header files that you need

--- a/bind/python/requirements.txt
+++ b/bind/python/requirements.txt
@@ -3,4 +3,4 @@ cppyy-backend==1.15.2
 cppyy-cling==6.30.0
 CPyCppyy==1.12.16
 pkgconfig==1.5.5
-hipopy==1.3.6
+hipopy==2.0.1


### PR DESCRIPTION
This PR updates the `hipopy` dependency for the python examples and adds some guidance on how to make them work with the `cppyy` libraries loaded in `pyiugana`.