### PR TITLE
fix: always reset created banks in Run functions

### DIFF
--- a/src/iguana/algorithms/Algorithm.cc
+++ b/src/iguana/algorithms/Algorithm.cc
@@ -291,7 +291,7 @@ namespace iguana {
 
   hipo::bank Algorithm::GetCreatedBank(std::string const& bank_name) const noexcept(false)
   {
-    return hipo::bank(GetCreatedBankSchema(bank_name));
+    return hipo::bank(GetCreatedBankSchema(bank_name), 0);
   }
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -357,7 +357,7 @@ namespace iguana {
     // create the schema, and add the new bank to `banks`
     auto bank_schema = GetCreatedBankSchema(bank_name);
     bank_idx         = banks.size();
-    banks.emplace_back(bank_schema);
+    banks.emplace_back(bank_schema, 0);
     return bank_schema;
   }
 

--- a/src/iguana/algorithms/clas12/CalorimeterLinker/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/CalorimeterLinker/Algorithm.cc
@@ -44,7 +44,7 @@ namespace iguana::clas12 {
       hipo::bank const& bank_calorimeter,
       hipo::bank& bank_result) const
   {
-
+    bank_result.reset(); // IMPORTANT: always first `reset` the created bank(s)
     ShowBank(bank_particle, Logger::Header("INPUT PARTICLE BANK"));
     ShowBank(bank_calorimeter, Logger::Header("INPUT CALORIMETER BANK"));
 

--- a/src/iguana/algorithms/clas12/MCProximityMatch/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/MCProximityMatch/Algorithm.cc
@@ -32,6 +32,7 @@ namespace iguana::clas12 {
       hipo::bank const& mc_particle_bank,
       hipo::bank& result_bank) const
   {
+    result_bank.reset(); // IMPORTANT: always first `reset` the created bank(s)
     ShowBank(rec_particle_bank, Logger::Header("INPUT RECONSTRUCTED PARTICLES"));
     ShowBank(mc_particle_bank, Logger::Header("INPUT GENERATED PARTICLE"));
 

--- a/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/SectorFinder/Algorithm.cc
@@ -77,6 +77,7 @@ namespace iguana::clas12 {
       hipo::bank const* userNeutralBank,
       hipo::bank* resultBank) const
   {
+    resultBank->reset(); // IMPORTANT: always first `reset` the created bank(s)
 
     std::vector<int> sectors_track;
     std::vector<int> pindices_track;

--- a/src/iguana/algorithms/clas12/TrajLinker/Algorithm.cc
+++ b/src/iguana/algorithms/clas12/TrajLinker/Algorithm.cc
@@ -39,6 +39,7 @@ namespace iguana::clas12 {
       hipo::bank const& bank_traj,
       hipo::bank& bank_result) const
   {
+    bank_result.reset(); // IMPORTANT: always first `reset` the created bank(s)
     ShowBank(bank_particle, Logger::Header("INPUT PARTICLE BANK"));
     ShowBank(bank_traj, Logger::Header("INPUT TRAJECTORY BANK"));
 

--- a/src/iguana/algorithms/physics/Depolarization/Algorithm.cc
+++ b/src/iguana/algorithms/physics/Depolarization/Algorithm.cc
@@ -31,6 +31,7 @@ namespace iguana::physics {
       hipo::bank const& inc_kin_bank,
       hipo::bank& result_bank) const
   {
+    result_bank.reset(); // IMPORTANT: always first `reset` the created bank(s)
     ShowBank(inc_kin_bank, Logger::Header("INPUT INCLUSIVE KINEMATICS"));
 
     // set `result_bank` rows and rowlist to match those of `inc_kin_bank`

--- a/src/iguana/algorithms/physics/DihadronKinematics/Algorithm.cc
+++ b/src/iguana/algorithms/physics/DihadronKinematics/Algorithm.cc
@@ -66,6 +66,7 @@ namespace iguana::physics {
       hipo::bank const& inc_kin_bank,
       hipo::bank& result_bank) const
   {
+    result_bank.reset(); // IMPORTANT: always first `reset` the created bank(s)
     ShowBank(particle_bank, Logger::Header("INPUT PARTICLES"));
 
     if(particle_bank.getRowList().empty() || inc_kin_bank.getRowList().empty()) {

--- a/src/iguana/algorithms/physics/InclusiveKinematics/Algorithm.cc
+++ b/src/iguana/algorithms/physics/InclusiveKinematics/Algorithm.cc
@@ -92,6 +92,7 @@ namespace iguana::physics {
       hipo::bank const& config_bank,
       hipo::bank& result_bank) const
   {
+    result_bank.reset(); // IMPORTANT: always first `reset` the created bank(s)
     ShowBank(particle_bank, Logger::Header("INPUT PARTICLES"));
 
     auto key = PrepareEvent(config_bank.getInt("run", 0));

--- a/src/iguana/algorithms/physics/SingleHadronKinematics/Algorithm.cc
+++ b/src/iguana/algorithms/physics/SingleHadronKinematics/Algorithm.cc
@@ -49,6 +49,7 @@ namespace iguana::physics {
       hipo::bank const& inc_kin_bank,
       hipo::bank& result_bank) const
   {
+    result_bank.reset(); // IMPORTANT: always first `reset` the created bank(s)
     ShowBank(particle_bank, Logger::Header("INPUT PARTICLES"));
 
     if(particle_bank.getRowList().empty() || inc_kin_bank.getRowList().empty()) {


### PR DESCRIPTION
- call `reset()` as the first thing in all creator algorithms' `Run` functions
  - fixes #402
- call the "proper" `hipo::bank` constructor, when creating new banks
  - this is the one that sets the number of rows initially to `0`, among other things
  - prior to this, calling `reset()` would crash for banks that Iguana creates